### PR TITLE
feat: implement update chatbot and passed all edit chatbot tests

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -8,10 +8,11 @@ from typing import Optional
 class NameIsRequired(Exception):
     pass
 
+class BotNotFound(Exception):
+    pass
 
 class SystemPromptIsRequired(Exception):
     pass
-
 
 class UnsupportedModel(Exception):
     pass
@@ -62,7 +63,7 @@ class BotUpdate(BaseModel):
     model: Optional[str] = None
     adapter: Optional[str] = None
 
-    def validate(self):
+    def validate(self, bot):
         if self.adapter and self.adapter not in MessageAdapter._value2member_map_:
             raise UnsupportedAdapter
         if self.name is not None and len(self.name) == 0:
@@ -71,3 +72,5 @@ class BotUpdate(BaseModel):
             raise SystemPromptIsRequired
         if self.model and self.model not in ModelEngine._value2member_map_:
             raise UnsupportedModel
+        if not bot:
+            raise BotNotFound

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,6 +2,7 @@ import enum
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, UUID4
+from typing import Optional
 
 
 class NameIsRequired(Exception):
@@ -53,4 +54,20 @@ class BotCreate(BaseModel):
         if len(self.system_prompt) == 0:
             raise SystemPromptIsRequired
         if self.model not in ModelEngine._value2member_map_:
+            raise UnsupportedModel
+        
+class BotUpdate(BaseModel):
+    name: Optional[str] = None
+    system_prompt: Optional[str] = None
+    model: Optional[str] = None
+    adapter: Optional[str] = None
+
+    def validate(self):
+        if self.adapter and self.adapter not in MessageAdapter._value2member_map_:
+            raise UnsupportedAdapter
+        if self.name is not None and len(self.name) == 0:
+            raise NameIsRequired
+        if self.system_prompt is not None and len(self.system_prompt) == 0:
+            raise SystemPromptIsRequired
+        if self.model and self.model not in ModelEngine._value2member_map_:
             raise UnsupportedModel

--- a/bot/controller.py
+++ b/bot/controller.py
@@ -15,7 +15,7 @@ class BotController(ABC):
         pass
 
     @abstractmethod
-    def update_chatbot(self, request: BotUpdate):
+    def update_chatbot(self, bot_id, request: BotUpdate):
         pass
 
 

--- a/bot/controller.py
+++ b/bot/controller.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from fastapi import HTTPException
 
-from .bot import BotCreate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
+from .bot import BotCreate, BotUpdate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
 from .service import BotService
 
 
@@ -12,6 +12,10 @@ class BotController(ABC):
 
     @abstractmethod
     def create_chatbot(self, request: BotCreate):
+        pass
+
+    @abstractmethod
+    def update_chatbot(self, request: BotUpdate):
         pass
 
 
@@ -27,6 +31,21 @@ class BotControllerV1(BotController):
         try:
             self.service.create_chatbot(request)
             return {"detail": "Bot created successfully!"}
+        except NameIsRequired:
+            raise HTTPException(status_code=400, detail="Name is required")
+        except SystemPromptIsRequired:
+            raise HTTPException(status_code=400, detail="System prompt is required")
+        except UnsupportedModel:
+            raise HTTPException(status_code=400, detail="Unsupported model")
+        except UnsupportedAdapter:
+            raise HTTPException(status_code=400, detail="Unsupported message adapter")
+        except Exception:
+            raise HTTPException(status_code=500, detail="Something went wrong")
+        
+    def update_chatbot(self, bot_id, request: BotUpdate):
+        try:
+            self.service.update_chatbot(bot_id, request)
+            return {"detail": "Bot updated successfully!"}
         except NameIsRequired:
             raise HTTPException(status_code=400, detail="Name is required")
         except SystemPromptIsRequired:

--- a/bot/controller.py
+++ b/bot/controller.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from fastapi import HTTPException
 
-from .bot import BotCreate, BotUpdate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
+from .bot import BotCreate, BotNotFound, BotUpdate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
 from .service import BotService
 
 
@@ -54,5 +54,7 @@ class BotControllerV1(BotController):
             raise HTTPException(status_code=400, detail="Unsupported model")
         except UnsupportedAdapter:
             raise HTTPException(status_code=400, detail="Unsupported message adapter")
+        except BotNotFound:
+            raise HTTPException(status_code=400, detail="Bot not found")
         except Exception:
             raise HTTPException(status_code=500, detail="Something went wrong")

--- a/bot/repository.py
+++ b/bot/repository.py
@@ -75,13 +75,13 @@ class PostgresBotRepository(BotRepository):
 
     def update_bot(self, bot, bot_update: BotUpdate = None):
         with self.create_session() as session:
-            with self.logger.catch(message="update bot error", reraise=True):                
+            with self.logger.catch(message="update bot error", reraise=True): 
+                session.add(bot)           
+
                 bot.name = bot_update.name
                 bot.system_prompt = bot_update.system_prompt
                 bot.model = bot_update.model            
                 bot.adapter = bot_update.adapter
 
-                
                 session.commit()
-
                 return bot

--- a/bot/service.py
+++ b/bot/service.py
@@ -36,8 +36,10 @@ class BotServiceV1(BotService):
         return
     
     def update_chatbot(self, bot_id, request: BotUpdate):
-        request.validate()
 
-        self.repository.update_bot(bot_id, request)
+        bot = self.repository.find_bot_by_id(bot_id)   
+        request.validate(bot)
+
+        self.repository.update_bot(bot, request)
 
         return

--- a/bot/service.py
+++ b/bot/service.py
@@ -41,5 +41,3 @@ class BotServiceV1(BotService):
         request.validate(bot)
 
         self.repository.update_bot(bot, request)
-
-        return

--- a/bot/service.py
+++ b/bot/service.py
@@ -2,7 +2,7 @@ from abc import abstractmethod, ABC
 from loguru import logger
 
 from .repository import BotRepository
-from .bot import Bot, BotCreate
+from .bot import Bot, BotCreate, BotUpdate
 
 
 class BotService(ABC):
@@ -12,6 +12,10 @@ class BotService(ABC):
 
     @abstractmethod
     def create_chatbot(self, request: BotCreate):
+        pass
+
+    @abstractmethod
+    def update_chatbot(self, bot_id:str, request: BotUpdate):
         pass
 
 
@@ -28,5 +32,12 @@ class BotServiceV1(BotService):
         request.validate()
 
         self.repository.create_bot(request)
+
+        return
+    
+    def update_chatbot(self, bot_id, request: BotUpdate):
+        request.validate()
+
+        self.repository.update_bot(bot_id, request)
 
         return

--- a/bot/test_bot.py
+++ b/bot/test_bot.py
@@ -1,7 +1,45 @@
-from .bot import BotCreate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
-
+from uuid import uuid4
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
 import pytest
 
+from .bot import BotCreate, BotUpdate, NameIsRequired, SystemPromptIsRequired, UnsupportedAdapter, UnsupportedModel
+from .service import BotServiceV1
+from .repository import BotModel, PostgresBotRepository
+from .controller import BotControllerV1
+
+
+# Setup 
+TEST_DATABASE_URL = "sqlite:///:memory:"  # Change as needed for your test setup
+
+@pytest.fixture
+def session(setup_database):
+    """Create a new database session for each test."""
+    SessionLocal = sessionmaker(bind=setup_database)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+@pytest.fixture
+def setup_repository(session):
+    """Set up the repository with the test session."""
+    repository = PostgresBotRepository(session=lambda: session)
+    return repository
+
+@pytest.fixture
+def setup_service(setup_repository):
+    """Set up the service with the repository."""
+    service = BotServiceV1(setup_repository)
+    return service
+
+@pytest.fixture
+def setup_controller(setup_service):
+    """Set up the controller with the service."""
+    controller = BotControllerV1(setup_service)
+    return controller
+
+# Tests
 
 class TestBotCreate:
     def test_empty_name(self):
@@ -59,3 +97,121 @@ class TestBotCreate:
         for test in tests:
             request = BotCreate(**test)
             request.validate()
+
+
+@pytest.fixture(scope="module")
+def setup_database():
+    """Create a test database and tables."""
+    engine = create_engine(TEST_DATABASE_URL)
+    BotModel.metadata.create_all(engine)
+    
+    yield engine
+
+    BotModel.metadata.drop_all(engine)
+
+class TestUpdateChatbot:
+    def test_update_chatbot_success(self, setup_controller):
+        
+        create_request = BotCreate(
+            name="Old Bot",
+            system_prompt="Old prompt",
+            model="OpenAI",
+            adapter="Slack"
+        )
+        setup_controller.service.create_chatbot(create_request)  # Use the service to create the bot
+        created_bot = setup_controller.service.repository.find_bots(0, 10)
+        
+        bot_update_request = BotUpdate(
+            name="Updated Bot",
+            system_prompt="Updated prompt",
+            model="OpenAI",
+            adapter="Slack"
+        )
+
+        response = setup_controller.update_chatbot(created_bot[0].id, bot_update_request)
+        assert response == {"detail": "Bot updated successfully!"}
+        
+        updated_bot = setup_controller.service.repository.find_bots(0, 10)
+        assert updated_bot[0].name == "Updated Bot"
+        assert updated_bot[0].system_prompt == "Updated prompt"
+
+    def test_update_chatbot_name_required(self, setup_controller):
+        controller = setup_controller
+
+        bot_update_request = BotUpdate(
+            name="",
+            system_prompt="Updated prompt",
+            model="OpenAI",
+            adapter="Slack"
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            controller.update_chatbot("some-uuid", bot_update_request)
+        
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Name is required"
+
+    def test_update_chatbot_system_prompt_required(self, setup_controller):
+        controller = setup_controller
+
+        bot_update_request = BotUpdate(
+            name="Updated Bot",
+            system_prompt="",
+            model="OpenAI",
+            adapter="Slack"
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            controller.update_chatbot("some-uuid", bot_update_request)
+        
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "System prompt is required"
+
+    def test_update_chatbot_unsupported_model(self, setup_controller):
+        controller = setup_controller
+
+        bot_update_request = BotUpdate(
+            name="Updated Bot",
+            system_prompt="Updated prompt",
+            model="UnsupportedModel",
+            adapter="Slack"
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            controller.update_chatbot("some-uuid", bot_update_request)
+        
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Unsupported model"
+
+    def test_update_chatbot_unsupported_adapter(self, setup_controller):
+        controller = setup_controller
+
+        bot_update_request = BotUpdate(
+            name="Updated Bot",
+            system_prompt="Updated prompt",
+            model="OpenAI",
+            adapter="UnsupportedAdapter"
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            controller.update_chatbot("some-uuid", bot_update_request)
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Unsupported message adapter"
+
+    def test_update_chatbot_general_exception(self, setup_controller):
+        controller = setup_controller
+
+        bot_update_request = BotUpdate(
+            name="Updated Bot",
+            system_prompt="Updated prompt",
+            model="OpenAI",
+            adapter="Slack"
+        )
+
+        controller.service.repository.update_bot = lambda bot_id, bot_update: (_ for _ in ()).throw(Exception) 
+
+        with pytest.raises(HTTPException) as exc:
+            controller.update_chatbot("some-uuid", bot_update_request)
+
+        assert exc.value.status_code == 500

--- a/bot/test_bot.py
+++ b/bot/test_bot.py
@@ -130,6 +130,11 @@ class TestUpdateChatbot:
         response = setup_controller.update_chatbot(created_bot[0].id, bot_update_request)
         assert response == {"detail": "Bot updated successfully!"}
 
+        updated_bot = setup_controller.service.repository.find_bots(0, 10)
+        assert updated_bot[0].name == "Updated Bot"
+        assert updated_bot[0].system_prompt == "Updated prompt"
+
+
     def test_update_chatbot_name_required(self, setup_controller):
         controller = setup_controller
 

--- a/main.py
+++ b/main.py
@@ -46,6 +46,12 @@ if __name__ == "__main__":
         status_code=status.HTTP_201_CREATED,
     )
     app.add_api_route(
+        "/api/bots/{bot_id}",
+        endpoint=bot_controller.update_chatbot,
+        methods=["PATCH"],
+        status_code=status.HTTP_200_OK,
+    )
+    app.add_api_route(
         "/api/slack/events", endpoint=slack_adapter.handle_events, methods=["POST"]
     )
 


### PR DESCRIPTION
- Added `update_bot` method in `PostgresBotRepository` for updating chatbot details.
- Created `update_bot` method in `BotServiceV1` to handle business logic.
- Implemented `update_bot` method in `BotControllerV1` to expose the endpoint.
- Included validation for bot properties and error handling in the controller.
- Added unit tests to verify successful updates and error scenarios.