### PR TITLE
[Refactor] Remove unused 'bot_id' variable

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -25,7 +25,7 @@ class SlackAdapter:
           
         parts = parameter.split(" ", 1) 
         if len(parts) == 2:
-            bot_id, question = parts
+            _, question = parts
         else:
             raise HTTPException(status_code=400, detail="Missing parameter in the request.")
 


### PR DESCRIPTION
- Replaced 'bot_id, question = parts' with '_, question = parts' to resolve the code smell.
- 'bot_id' was assigned but not used, leading to unnecessary variable declaration.
- Using '_' as a placeholder improves code readability and avoids confusion with unused variables