### PR TITLE
ci: add zerotier vpn and database migration step

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v5
@@ -56,7 +58,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base master
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -54,11 +54,28 @@ jobs:
       - name: Setup coverage and pytest
         run: pip install coverage pytest
 
+      - name: Get list of changed migration files
+        id: migration-changes-list
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            files:
+              - 'migrations/**'
+          list-files: json
+
+      - name: Get number of changed migration files
+        id: migration-changes
+        run: |
+          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.files }}
+          MIGRATION_CHANGES_COUNT=$(echo $MIGRATION_CHANGES_LIST | jq length)
+          echo "count=$MIGRATION_CHANGES_COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Setup Atlas
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
+        if: ${{ steps.migration-changes.outputs.count > 0 }}
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --latest ${{ steps.migration-changes.outputs.count }}
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -59,14 +59,14 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            files:
+            changed:
               - 'migrations/**'
           list-files: json
 
       - name: Get number of changed migration files
         id: migration-changes
         run: |
-          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.files }}
+          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.changed_files }}
           MIGRATION_CHANGES_COUNT=$(echo $MIGRATION_CHANGES_LIST | jq length)
           echo "count=$MIGRATION_CHANGES_COUNT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Setup Atlas
         uses: ariga/setup-atlas@v0
 
+      - name: Lint migration files
+        uses: ariga/atlas-action/migrate/lint@v1
+        with:
+          dir: file://migrations
+          dev-url: postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
+
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -56,10 +56,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        uses: ariga/atlas-action/migrate/lint@v1
-        with:
-          dir: file://migrations
-          dev-url: postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -5,6 +5,7 @@ env:
   CONFIG_DIR: infra/stg
   DEPLOY_DIR: sapungobrol
   ENV: ${{ secrets.STG_ENV }}
+  DATABASE_MIGRATE_URL: ${{ secrets.STG_DATABASE_MIGRATE_URL }}
   # VM variables
   HOST: ${{ vars.STG_SSH_HOST }}
   PORT: ${{ vars.STG_SSH_PORT }}
@@ -174,3 +175,6 @@ jobs:
       - name: Run containers based on docker compose
         run: |
           ssh ${{ env.HOST }} 'sudo bash -c "cd ${{ env.DEPLOY_DIR }}; docker compose pull; docker compose down; docker compose up -d"'
+
+      - name: Apply database migrations
+        run: atlas migrate apply --url ${{ env.DATABASE_MIGRATE_URL }}

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,8 +40,6 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup python
         uses: actions/setup-python@v5
@@ -58,7 +56,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base master
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -109,6 +109,29 @@ jobs:
     needs: [build]
     runs-on: ubuntu-24.04
     steps:
+      - name: Connect to ZeroTier
+        uses: zerotier/github-action@v1.0.1
+        with:
+          network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
+          auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+
+      - name: Ping ZeroTier host
+        shell: bash
+        run: |
+          count=60 # 1 minute
+          while ! ping -c 1 ${{ secrets.ZEROTIER_HOST_IP }} ; do
+            echo "Waiting..." ;
+            sleep 1 ;
+            let count=count-1
+          done
+
+          if [ $count -eq 0 ]; then
+            echo "Failed to ping host"
+            exit 1
+          fi
+
+          echo "Ping success!"
+
       - name: Checkout Sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,10 +42,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        uses: ariga/atlas-action/migrate/lint@v1
-        with:
-          dir: file://migrations
-          dev-url: postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,14 +45,14 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            files:
+            changed:
               - 'migrations/**'
           list-files: json
 
       - name: Get number of changed migration files
         id: migration-changes
         run: |
-          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.files }}
+          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.changed_files }}
           MIGRATION_CHANGES_COUNT=$(echo $MIGRATION_CHANGES_LIST | jq length)
           echo "count=$MIGRATION_CHANGES_COUNT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base --git-base master
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Setup Atlas
         uses: ariga/setup-atlas@v0
 
+      - name: Lint migration files
+        uses: ariga/atlas-action/migrate/lint@v1
+        with:
+          dir: file://migrations
+          dev-url: postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
+
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,11 +40,28 @@ jobs:
       - name: Setup coverage and pytest
         run: pip install coverage pytest
 
+      - name: Get list of changed migration files
+        id: migration-changes-list
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            files:
+              - 'migrations/**'
+          list-files: json
+
+      - name: Get number of changed migration files
+        id: migration-changes
+        run: |
+          MIGRATION_CHANGES_LIST=${{ steps.migration-changes-list.outputs.files }}
+          MIGRATION_CHANGES_COUNT=$(echo $MIGRATION_CHANGES_LIST | jq length)
+          echo "count=$MIGRATION_CHANGES_COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Setup Atlas
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
+        if: ${{ steps.migration-changes.outputs.count > 0 }}
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --latest ${{ steps.migration-changes.outputs.count }}
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v5
@@ -42,7 +44,7 @@ jobs:
         uses: ariga/setup-atlas@v0
 
       - name: Lint migration files
-        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base --git-base master
+        run: atlas migrate lint --dir file://migrations --dev-url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable --git-base main
 
       - name: Run migrations
         run: atlas migrate apply --url postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable

--- a/infra/stg/docker-compose.yml
+++ b/infra/stg/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    ports:
+      - 10.243.242.62:5433:5432
     networks:
       - sapungobrol-stg
     volumes:


### PR DESCRIPTION
I've setup a VPN to our staging server using ZeroTier. This way, we can access the database through the deployment pipeline and do the database migrations automatically over the VPN instead of exposing it through the public network.

This PR is made to support that change by setting up ZeroTier on the pipeline and applying the migrations after a successful container run