### PR TITLE
test: patch openai api key for default port test

### DIFF
--- a/config/test_config.py
+++ b/config/test_config.py
@@ -26,6 +26,7 @@ class TestAppConfig:
 
     def test_config_default_port(self, monkeypatch):
         monkeypatch.setenv("PORT", "")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-openai-api-key")
 
         config = AppConfig()
 


### PR DESCRIPTION
This PR is to fix one of the tests that failed due to a missing dependency in one of the env variable