### PR TITLE
feat: implement slackbot list-bots command

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -71,7 +71,7 @@ class SlackAdapter:
         
         bot_responses = self.bot_controller.fetch_chatbots()
         
-        response_text = f"{len(bot_responses)} Active Bots:"
+        response_text = f"{len(bot_responses)} Active Bot(s)"
         response_text += ''.join([f'\n- {bot_response.name} ({bot_response.id})' for bot_response in bot_responses])
         
         try:

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -75,15 +75,7 @@ class SlackAdapter:
         response_text += ''.join([f'\n- {bot_response.name} ({bot_response.id})' for bot_response in bot_responses])
         
         try:
-            response = self.app.client.chat_postMessage(channel=channel_id, text=response_text)
-            thread_ts = response["ts"]
+            self.app.client.chat_postMessage(channel=channel_id, text=response_text)
             return Response(status_code=200)
-
         except SlackApiError as e:
-            if 'thread_ts' in locals():
-                try:
-                    self.app.client.chat_delete(channel=channel_id, ts=thread_ts)
-                except SlackApiError as delete_error:
-                    raise HTTPException(status_code=400, detail=f"Slack API Error : {delete_error}")
-
             raise HTTPException(status_code=400, detail=f"Slack API Error : {e}")

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -3,10 +3,10 @@ from loguru import logger
 from slack_bolt import App
 from slack_bolt.adapter.fastapi import SlackRequestHandler
 from slack_sdk.errors import SlackApiError
-from bot import BotControllerV1
+from bot.controller import BotController
 
 class SlackAdapter:
-    def __init__(self, app: App, bot_controller: BotControllerV1) -> None:
+    def __init__(self, app: App, bot_controller: BotController) -> None:
         self.app = app
         self.bot_controller = bot_controller
         self.handler = SlackRequestHandler(self.app)
@@ -58,12 +58,11 @@ class SlackAdapter:
         data = await request.form()
     
         channel_id = data.get("channel_id")
-        user_id = data.get("user_id")
         
-        bot_responses = self.bot_controller.fetch_chatbots()[0]
+        bot_responses = self.bot_controller.fetch_chatbots()
         
         response_text = f"{len(bot_responses)} Active Bots:"
-        response_text += ''.join([f'\n- {bot_response['name']}' for bot_response in bot_responses])
+        response_text += ''.join([f'\n- {bot_response.name} ({bot_response.id})' for bot_response in bot_responses])
         
         try:
             response = self.app.client.chat_postMessage(channel=channel_id, text=response_text)

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -3,10 +3,12 @@ from loguru import logger
 from slack_bolt import App
 from slack_bolt.adapter.fastapi import SlackRequestHandler
 from slack_sdk.errors import SlackApiError
+from bot import BotControllerV1
 
 class SlackAdapter:
-    def __init__(self, app: App) -> None:
+    def __init__(self, app: App, bot_controller: BotControllerV1) -> None:
         self.app = app
+        self.bot_controller = bot_controller
         self.handler = SlackRequestHandler(self.app)
         self.logger = logger.bind(service="SlackAdapter")
 
@@ -51,4 +53,6 @@ class SlackAdapter:
                     raise HTTPException(status_code=400, detail=f"Slack API Error : {delete_error}")
 
             raise HTTPException(status_code=400, detail=f"Slack API Error : {e}")
-        
+    
+    async def list_bots(self, request: Request):
+        pass

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -157,8 +157,7 @@ class TestAppConfig:
                 
                 mock_app.client.chat_postMessage = MagicMock(
                     side_effect=[
-                        {"ts": "1234567890.123456"},  
-                        {"ok": True} 
+                        {"ts": "1234567890.123456"},
                     ]
                 )
                 

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -194,7 +194,7 @@ class TestAppConfig:
         )
     
     @pytest.mark.asyncio
-    async def test_listbots_method(self, mock_slack_adapter, mock_request):
+    async def test_list_bots_method(self, mock_slack_adapter, mock_request):
         mock_app, _, mock_bot_controller, slack_adapter = mock_slack_adapter
         
         mock_app.client.chat_postMessage = MagicMock(
@@ -245,7 +245,7 @@ class TestAppConfig:
         assert response.status_code == 200
     
     @pytest.mark.asyncio
-    async def test_listbots_method_chat_postMessage_failure(self, mock_slack_adapter, mock_request):
+    async def test_list_bots_method_chat_postMessage_failure(self, mock_slack_adapter, mock_request):
         mock_app, _, mock_bot_controller, slack_adapter = mock_slack_adapter
         
         mock_app.client.chat_postMessage = MagicMock(

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -239,7 +239,7 @@ class TestAppConfig:
         
         mock_app.client.chat_postMessage.assert_any_call(
             channel="C12345678",
-            text=f"2 Active Bots:\n- Bot A ({first_bot_id})\n- Bot B ({second_bot_id})"
+            text=f"2 Active Bot(s)\n- Bot A ({first_bot_id})\n- Bot B ({second_bot_id})"
         )
         
         assert response.status_code == 200

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -26,6 +26,38 @@ class TestAppConfig:
     def mock_request(self):
         mock_request = MagicMock(spec=Request)
         return mock_request
+    
+    @pytest.fixture
+    def mock_bot_response_list(self):
+        first_bot_id = uuid4()
+        second_bot_id = uuid4()
+        
+        mock_bot_response_list = MagicMock(
+            return_value=[
+                BotResponse(
+                    id = first_bot_id,
+                    name = "Bot A",
+                    system_prompt = "prompt A here",
+                    model = ModelEngine.OPENAI,
+                    adapter = MessageAdapter.SLACK,
+                    created_at = datetime.fromisocalendar(2024, 1, 1),
+                    updated_at = datetime.fromisocalendar(2024, 1, 1),
+                    updated_at_relative = relative_time(datetime.fromisocalendar(2024, 1, 1)),
+                ),
+                BotResponse(
+                    id = second_bot_id,
+                    name = "Bot B",
+                    system_prompt = "a much longer prompt B here",
+                    model = ModelEngine.OPENAI,
+                    adapter = MessageAdapter.SLACK,
+                    created_at = datetime.now(),
+                    updated_at = datetime.now(),
+                    updated_at_relative = relative_time(datetime.now()),
+                )
+            ]
+        )
+        
+        return first_bot_id, second_bot_id, mock_bot_response_list
 
     async def common_mock_request(self, mock_request, text):
         mock_request.form = AsyncMock(return_value={
@@ -194,7 +226,7 @@ class TestAppConfig:
         )
     
     @pytest.mark.asyncio
-    async def test_list_bots_method(self, mock_slack_adapter, mock_request):
+    async def test_list_bots_method(self, mock_slack_adapter, mock_request, mock_bot_response_list):
         mock_app, _, mock_bot_controller, slack_adapter = mock_slack_adapter
         
         mock_app.client.chat_postMessage = MagicMock(
@@ -203,33 +235,7 @@ class TestAppConfig:
             ]
         )
         
-        first_bot_id = uuid4()
-        second_bot_id = uuid4()
-        
-        mock_bot_controller.fetch_chatbots = MagicMock(
-            return_value=[
-                BotResponse(
-                    id = first_bot_id,
-                    name = "Bot A",
-                    system_prompt = "prompt A here",
-                    model = ModelEngine.OPENAI,
-                    adapter = MessageAdapter.SLACK,
-                    created_at = datetime.fromisocalendar(2024, 1, 1),
-                    updated_at = datetime.fromisocalendar(2024, 1, 1),
-                    updated_at_relative = relative_time(datetime.fromisocalendar(2024, 1, 1)),
-                ),
-                BotResponse(
-                    id = second_bot_id,
-                    name = "Bot B",
-                    system_prompt = "a much longer prompt B here",
-                    model = ModelEngine.OPENAI,
-                    adapter = MessageAdapter.SLACK,
-                    created_at = datetime.now(),
-                    updated_at = datetime.now(),
-                    updated_at_relative = relative_time(datetime.now()),
-                )
-            ]
-        )
+        first_bot_id, second_bot_id, mock_bot_controller.fetch_chatbots = mock_bot_response_list
         
         mock_request = await self.common_mock_request(mock_request, "")
         
@@ -245,7 +251,7 @@ class TestAppConfig:
         assert response.status_code == 200
     
     @pytest.mark.asyncio
-    async def test_list_bots_method_post_message_failure(self, mock_slack_adapter, mock_request):
+    async def test_list_bots_method_post_message_failure(self, mock_slack_adapter, mock_request, mock_bot_response_list):
         mock_app, _, mock_bot_controller, slack_adapter = mock_slack_adapter
         
         mock_app.client.chat_postMessage = MagicMock(
@@ -254,33 +260,7 @@ class TestAppConfig:
             ]
         )
         
-        first_bot_id = uuid4()
-        second_bot_id = uuid4()
-        
-        mock_bot_controller.fetch_chatbots = MagicMock(
-            return_value=[
-                BotResponse(
-                    id = first_bot_id,
-                    name = "Bot A",
-                    system_prompt = "prompt A here",
-                    model = ModelEngine.OPENAI,
-                    adapter = MessageAdapter.SLACK,
-                    created_at = datetime.fromisocalendar(2024, 1, 1),
-                    updated_at = datetime.fromisocalendar(2024, 1, 1),
-                    updated_at_relative = relative_time(datetime.fromisocalendar(2024, 1, 1)),
-                ),
-                BotResponse(
-                    id = second_bot_id,
-                    name = "Bot B",
-                    system_prompt = "a much longer prompt B here",
-                    model = ModelEngine.OPENAI,
-                    adapter = MessageAdapter.SLACK,
-                    created_at = datetime.now(),
-                    updated_at = datetime.now(),
-                    updated_at_relative = relative_time(datetime.now()),
-                )
-            ]
-        )
+        _, _, mock_bot_controller.fetch_chatbots = mock_bot_response_list
         
         mock_request = await self.common_mock_request(mock_request, "")
 

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -10,132 +10,198 @@ class TestAppConfig:
     @pytest.mark.asyncio
     async def test_ask_method(self):
         with patch('slack_bolt.App') as MockApp:
-            mock_app = MockApp()
-            
-            mock_app.client.chat_postMessage = MagicMock(
-                side_effect=[
-                    {"ts": "1234567890.123456"},  
-                    {"ok": True} 
-                ]
-            )
+            with patch('bot.BotControllerV1') as MockBotController:
+                mock_app = MockApp()
+                mock_bot_controller = MockBotController()
+                
+                mock_app.client.chat_postMessage = MagicMock(
+                    side_effect=[
+                        {"ts": "1234567890.123456"},  
+                        {"ok": True} 
+                    ]
+                )
 
-            slack_adapter = SlackAdapter(mock_app)
+                slack_adapter = SlackAdapter(mock_app, mock_bot_controller)
 
-            mock_request = MagicMock(spec=Request)
-            mock_request.form = AsyncMock(return_value={
-                "channel_id": "C12345678",
-                "user_id": "U12345678",
-                "text": "12 How are you?"
-            })
+                mock_request = MagicMock(spec=Request)
+                mock_request.form = AsyncMock(return_value={
+                    "channel_id": "C12345678",
+                    "user_id": "U12345678",
+                    "text": "12 How are you?"
+                })
 
-            response = await slack_adapter.ask(mock_request)
+                response = await slack_adapter.ask(mock_request)
 
-            assert mock_app.client.chat_postMessage.call_count == 2
+                assert mock_app.client.chat_postMessage.call_count == 2
 
-            mock_app.client.chat_postMessage.assert_any_call(
-                channel="C12345678",
-                text="How are you? \n\n<@U12345678>"
-            )
+                mock_app.client.chat_postMessage.assert_any_call(
+                    channel="C12345678",
+                    text="How are you? \n\n<@U12345678>"
+                )
 
-            mock_app.client.chat_postMessage.assert_any_call(
-                channel="C12345678",
-                text="This is a reply to the message.",
-                thread_ts="1234567890.123456"
-            )
+                mock_app.client.chat_postMessage.assert_any_call(
+                    channel="C12345678",
+                    text="This is a reply to the message.",
+                    thread_ts="1234567890.123456"
+                )
 
-            assert response.status_code == 200
+                assert response.status_code == 200
 
     @pytest.mark.asyncio 
     async def test_missing_parameter_incomplete_text(self):
         with patch('slack_bolt.App') as MockApp:
-            mock_app = MockApp()
-            mock_app.client.chat_postMessage = MagicMock()
+            with patch('bot.BotControllerV1') as MockBotController:
+                mock_app = MockApp()
+                mock_bot_controller = MockBotController()
+                mock_app.client.chat_postMessage = MagicMock()
 
-            slack_adapter = SlackAdapter(mock_app)
+                slack_adapter = SlackAdapter(mock_app, mock_bot_controller)
 
-            mock_request = MagicMock(spec=Request)
-            mock_request.form = AsyncMock(return_value={
-                "channel_id": "C12345678",
-                "user_id": "U12345678",
-                "text": "12"
-            })
+                mock_request = MagicMock(spec=Request)
+                mock_request.form = AsyncMock(return_value={
+                    "channel_id": "C12345678",
+                    "user_id": "U12345678",
+                    "text": "12"
+                })
 
-            with pytest.raises(HTTPException) as excinfo:
-                await slack_adapter.ask(mock_request)
-            
-            assert excinfo.value.status_code == 400
-            assert excinfo.value.detail == "Missing parameter in the request."
+                with pytest.raises(HTTPException) as excinfo:
+                    await slack_adapter.ask(mock_request)
+                
+                assert excinfo.value.status_code == 400
+                assert excinfo.value.detail == "Missing parameter in the request."
 
-            mock_app.client.chat_postMessage.assert_not_called()
+                mock_app.client.chat_postMessage.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_chat_post_message_failure(self):
         with patch('slack_bolt.App') as MockApp:
-            mock_app = MockApp()
-            
-            mock_app.client.chat_postMessage = MagicMock(
-                side_effect=[
-                    {"ts": "1234567890.123456"},
-                    SlackApiError("Error posting message", response={})
-                ]
-            )
-            mock_app.client.chat_delete = MagicMock()  
+            with patch('bot.BotControllerV1') as MockBotController:
+                mock_app = MockApp()
+                mock_bot_controller = MockBotController()
+                
+                mock_app.client.chat_postMessage = MagicMock(
+                    side_effect=[
+                        {"ts": "1234567890.123456"},
+                        SlackApiError("Error posting message", response={})
+                    ]
+                )
+                mock_app.client.chat_delete = MagicMock()  
 
-            slack_adapter = SlackAdapter(mock_app)
+                slack_adapter = SlackAdapter(mock_app, mock_bot_controller)
 
-            mock_request = MagicMock(spec=Request)
-            mock_request.form = AsyncMock(return_value={
-                "channel_id": "C12345678",
-                "user_id": "U12345678",
-                "text": "12 How are you?"
-            })
-            
-            with pytest.raises(HTTPException) as excinfo:
-                await slack_adapter.ask(mock_request)
+                mock_request = MagicMock(spec=Request)
+                mock_request.form = AsyncMock(return_value={
+                    "channel_id": "C12345678",
+                    "user_id": "U12345678",
+                    "text": "12 How are you?"
+                })
+                
+                with pytest.raises(HTTPException) as excinfo:
+                    await slack_adapter.ask(mock_request)
 
-            assert excinfo.value.status_code == 400
-            assert "Slack API Error" in excinfo.value.detail
+                assert excinfo.value.status_code == 400
+                assert "Slack API Error" in excinfo.value.detail
 
-            assert mock_app.client.chat_postMessage.call_count == 2
-            
-            mock_app.client.chat_delete.assert_called_once_with(
-                channel="C12345678",
-                ts="1234567890.123456"
-            )
+                assert mock_app.client.chat_postMessage.call_count == 2
+                
+                mock_app.client.chat_delete.assert_called_once_with(
+                    channel="C12345678",
+                    ts="1234567890.123456"
+                )
             
     @pytest.mark.asyncio
     async def test_chat_post_message_and_delete_failure(self):
         with patch('slack_bolt.App') as MockApp:
-            mock_app = MockApp()
-            
-            mock_app.client.chat_postMessage = MagicMock(
-                side_effect=[
-                    {"ts": "1234567890.123456"},
-                    SlackApiError("Error posting message", response={})
-                ]
-            )
-            mock_app.client.chat_delete = MagicMock(
-                side_effect=SlackApiError("Error delete message", response={})
+            with patch('bot.BotControllerV1') as MockBotController:
+                mock_app = MockApp()
+                mock_bot_controller = MockBotController()
+                
+                mock_app.client.chat_postMessage = MagicMock(
+                    side_effect=[
+                        {"ts": "1234567890.123456"},
+                        SlackApiError("Error posting message", response={})
+                    ]
+                )
+                mock_app.client.chat_delete = MagicMock(
+                    side_effect=SlackApiError("Error delete message", response={})
 
-            )
-            slack_adapter = SlackAdapter(mock_app)
+                )
+                slack_adapter = SlackAdapter(mock_app, mock_bot_controller)
 
-            mock_request = MagicMock(spec=Request)
-            mock_request.form = AsyncMock(return_value={
-                "channel_id": "C12345678",
-                "user_id": "U12345678",
-                "text": "12 How are you?"
-            })
+                mock_request = MagicMock(spec=Request)
+                mock_request.form = AsyncMock(return_value={
+                    "channel_id": "C12345678",
+                    "user_id": "U12345678",
+                    "text": "12 How are you?"
+                })
 
-            with pytest.raises(HTTPException) as excinfo:
-                await slack_adapter.ask(mock_request)
+                with pytest.raises(HTTPException) as excinfo:
+                    await slack_adapter.ask(mock_request)
 
-            assert excinfo.value.status_code == 400
-            assert "Slack API Error" in excinfo.value.detail
+                assert excinfo.value.status_code == 400
+                assert "Slack API Error" in excinfo.value.detail
 
-            assert mock_app.client.chat_postMessage.call_count == 2
-            
-            mock_app.client.chat_delete.assert_called_once_with(
-                channel="C12345678",
-                ts="1234567890.123456"
-            )
+                assert mock_app.client.chat_postMessage.call_count == 2
+                
+                mock_app.client.chat_delete.assert_called_once_with(
+                    channel="C12345678",
+                    ts="1234567890.123456"
+                )
+    
+    @pytest.mark.asyncio
+    async def test_listbots_method(self):
+        with patch('slack_bolt.App') as MockApp:
+            with patch('bot.BotControllerV1') as MockBotController:
+                mock_app = MockApp()
+                mock_bot_controller = MockBotController()
+                
+                mock_app.client.chat_postMessage = MagicMock(
+                    side_effect=[
+                        {"ts": "1234567890.123456"},  
+                        {"ok": True} 
+                    ]
+                )
+                
+                mock_bot_controller.fetch_chatbots = MagicMock(
+                    return_value=[
+                        [
+                            {
+                                'id': 'bot1',
+                                'name': 'Bot A',
+                                'system_prompt': 'Prompt A',
+                                'model': 'OpenAI',
+                                'adapter': 'Slack',
+                                'updated_at': '2024-10-04T00:00:00Z'
+                            },
+                            {
+                                'id': 'bot2',
+                                'name': 'Bot B',
+                                'system_prompt': 'Prompt B',
+                                'model': 'OpenAI',
+                                'adapter': 'Slack',
+                                'updated_at': '2024-10-04T00:00:00Z'
+                            }
+                        ]
+                    ]
+                )
+                
+                slack_adapter = SlackAdapter(mock_app, mock_bot_controller)
+
+                mock_request = MagicMock(spec=Request)
+                mock_request.form = AsyncMock(return_value={
+                    "channel_id": "C12345678",
+                    "user_id": "U12345678",
+                    "text": ""
+                })
+                
+                response = await slack_adapter.list_bots(mock_request)
+
+                assert mock_app.client.chat_postMessage.call_count == 1
+                
+                mock_app.client.chat_postMessage.assert_any_call(
+                    channel="C12345678",
+                    text="2 Active Bots:\n- Bot A\n- Bot B"
+                )
+                
+                assert response.status_code == 200
+                

--- a/adapter/test_adapter.py
+++ b/adapter/test_adapter.py
@@ -245,7 +245,7 @@ class TestAppConfig:
         assert response.status_code == 200
     
     @pytest.mark.asyncio
-    async def test_list_bots_method_chat_postMessage_failure(self, mock_slack_adapter, mock_request):
+    async def test_list_bots_method_post_message_failure(self, mock_slack_adapter, mock_request):
         mock_app, _, mock_bot_controller, slack_adapter = mock_slack_adapter
         
         mock_app.client.chat_postMessage = MagicMock(

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     bot_view = BotViewV1(bot_controller, bot_service)
 
-    slack_adapter = SlackAdapter(slack_app)
+    slack_adapter = SlackAdapter(slack_app, bot_controller)
 
     app = FastAPI()
     
@@ -85,6 +85,9 @@ if __name__ == "__main__":
     )
     app.add_api_route(
         "/api/slack/ask", endpoint=slack_adapter.ask, methods=["POST"]
+    )
+    app.add_api_route(
+        "/api/slack/list-bots", endpoint=slack_adapter.list_bots, methods=["POST"]
     )
 
 


### PR DESCRIPTION
Changes Made:
- Implemented `list_bots` method to be used when user is sending the `/list-bots` command in slack.

Testing:
- Added test for the `list_bots` method.