### PR TITLE
feat: slack message events listener

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -112,3 +112,12 @@ class SlackAdapter:
             return Response(status_code=200)
         except SlackApiError as e:
             raise HTTPException(status_code=400, detail=f"Slack API Error : {e}")
+    
+    def event_message(self, event, say):
+        pass
+    
+    def event_message_replied(self, event, say):
+        pass
+        
+    def bot_replied(self, event, say):
+        pass

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -313,3 +313,77 @@ class TestSlackAdapter:
         assert excinfo.value.status_code == 400
         assert "Slack API Error" in excinfo.value.detail
         assert mock_app.client.chat_postMessage.call_count == 1
+    
+    def test_event_message_without_thread(self, mock_slack_adapter):
+        _, _, _, slack_adapter = mock_slack_adapter
+        
+        mock_say = MagicMock()
+
+        event = {
+            "type": "message",
+            "channel": "C123ABC456",
+            "user": "U123ABC456",
+            "text": "Hello world",
+            "ts": "1355517523.000005"
+        }
+
+        slack_adapter.event_message_replied = MagicMock()
+
+        slack_adapter.event_message(event, mock_say)
+
+        slack_adapter.event_message_replied.assert_not_called()
+        
+    def test_event_message_with_thread_wrong_user(self, mock_slack_adapter):
+        _, _, _, slack_adapter = mock_slack_adapter
+        
+        mock_say = MagicMock()
+
+        event = {"thread_ts": "1355517523.000005", "channel": "C123ABC456"}
+
+        slack_adapter.app.client.conversations_history.return_value = {
+            "messages": [
+                {"user": "U123NONBOT", "text": '<@U07N64EUJ8Y> asked:\n\n"hello"'}
+            ]
+        }
+
+        slack_adapter.bot_replied = MagicMock()
+
+        slack_adapter.event_message(event, mock_say)
+
+        slack_adapter.bot_replied.assert_not_called()
+
+    def test_event_message_with_thread_wrong_parent_message(self, mock_slack_adapter):
+        _, _, _, slack_adapter = mock_slack_adapter
+        
+        mock_say = MagicMock()
+
+        event = {"thread_ts": "1355517523.000005", "channel": "C123ABC456"}
+
+        slack_adapter.app.client.conversations_history.return_value = {
+            "messages": [
+                {"user": slack_adapter.app_user_id, "text": "This is a random message"}
+            ]
+        }
+
+        slack_adapter.bot_replied = MagicMock()
+
+        slack_adapter.event_message(event, mock_say)
+
+        slack_adapter.bot_replied.assert_not_called()
+
+    def test_event_message_with_thread_bot_replied(self, mock_slack_adapter):
+        _, _, _, slack_adapter = mock_slack_adapter
+        
+        mock_say = MagicMock()
+
+        event = {"thread_ts": "1355517523.000005", "channel": "C123ABC456"}
+
+        slack_adapter.app.client.conversations_history.return_value = {
+            "messages": [
+                {"user": slack_adapter.app_user_id, "text": '<@U07N64EUJ8Y> asked:\n\n"hello"'}
+            ]
+        }
+
+        slack_adapter.event_message(event, mock_say)
+
+        mock_say.assert_called_once_with("To be implemented", thread_ts="1355517523.000005")

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ if __name__ == "__main__":
     engine_selector = ChatEngineSelector(openai_api_key=config.openai_api_key, anthropic_api_key=config.anthropic_api_key)
 
     slack_adapter = SlackAdapter(slack_app, engine_selector, bot_service)
+    
+    slack_app.event("message")(slack_adapter.event_message)
 
     app = FastAPI()
 


### PR DESCRIPTION
### Changes Made:

- Added slack message events listener that will handle all message events. 3 methods will be the handler, each with different subtypes of the events.

### Tests:

- Added unit tests to verify all new added methods route all relevant events subtypes to the correct method.