### PR TITLE
[SPN-2-33] Fix unexpected errors caused by long-running response generation

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -43,9 +43,11 @@ class SlackAdapter:
 
         except ChatResponseGenerationError as e:  # pragma: no cover
             self.logger.error(e)
-            return {
-                "text": "Something went wrong when trying to generate your response."
-            }
+            self.app.client.chat_update(
+                channel=channel,
+                ts=ts,
+                text="Something went wrong when trying to generate your response.",
+            )
 
     async def ask(self, request: Request):
         data = await request.form()

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -112,9 +112,10 @@ class TestSlackAdapter:
             "C12345678", "1234567890.654321", mock_chatbot, "How are you?"
         )
 
-        assert (
-            response["text"]
-            == "Something went wrong when trying to generate your response."
+        mock_app.client.chat_update.assert_called_once_with(
+            channel="C12345678",
+            ts="1234567890.654321",
+            text="Something went wrong when trying to generate your response.",
         )
 
     @pytest.mark.asyncio

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -1,5 +1,5 @@
 import pytest
-import sqlalchemy
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import Request, HTTPException
 from .slack import SlackAdapter
@@ -9,12 +9,11 @@ from uuid import uuid4
 from bot.bot import BotResponse, MessageAdapter, ModelEngine
 from bot.service import BotService
 from bot.helper import relative_time
-from chat import ChatEngineSelector
-from chat.openai_chat import ChatOpenAI
+from chat import ChatEngineSelector, ChatOpenAI
+from chat.exceptions import ChatResponseGenerationError
 
 
 class TestSlackAdapter:
-
     @pytest.fixture
     def mock_slack_adapter(self):
         with patch("slack_bolt.App") as MockApp:
@@ -77,6 +76,48 @@ class TestSlackAdapter:
         return mock_request
 
     @pytest.mark.asyncio
+    async def test_send_generated_response(self, mock_slack_adapter):
+        mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
+
+        # Mock Slack API calls
+        mock_app.client.chat_postMessage = MagicMock(
+            side_effect=[{"ts": "1234567890.123456"}, {"ts": "1234567890.654321"}]
+        )
+        mock_chatbot.generate_response = MagicMock(
+            return_value="Chatbot Reply: I'm fine, thank you!"
+        )
+
+        slack_adapter.send_generated_response(
+            "C12345678", "1234567890.654321", mock_chatbot, "How are you?"
+        )
+        mock_app.client.chat_update.assert_called_once_with(
+            channel="C12345678",
+            ts="1234567890.654321",
+            text="Chatbot Reply: I'm fine, thank you!",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_generated_response_generation_error(self, mock_slack_adapter):
+        mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
+
+        # Mock Slack API calls
+        mock_app.client.chat_postMessage = MagicMock(
+            side_effect=[{"ts": "1234567890.123456"}, {"ts": "1234567890.654321"}]
+        )
+        mock_chatbot.generate_response = MagicMock(
+            side_effect=ChatResponseGenerationError
+        )
+
+        response = slack_adapter.send_generated_response(
+            "C12345678", "1234567890.654321", mock_chatbot, "How are you?"
+        )
+
+        assert (
+            response["text"]
+            == "Something went wrong when trying to generate your response."
+        )
+
+    @pytest.mark.asyncio
     async def test_ask_method(self, mock_slack_adapter, mock_request):
         mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
 
@@ -94,11 +135,6 @@ class TestSlackAdapter:
         assert mock_app.client.chat_postMessage.call_count == 2
         mock_app.client.chat_postMessage.assert_any_call(
             channel="C12345678", text='<@U12345678> asked: \n\n"How are you?" '
-        )
-        mock_app.client.chat_update.assert_called_once_with(
-            channel="C12345678",
-            ts="1234567890.654321",
-            text="Chatbot Reply: I'm fine, thank you!",
         )
         assert response.status_code == 200
 
@@ -184,6 +220,8 @@ class TestSlackAdapter:
 
         await slack_adapter.ask(mock_request)
 
+        time.sleep(1)
+
         mock_chatbot.generate_response.assert_called_once_with(
             query='<@U12345678> asked: \n\n"How is the weather?" '
         )
@@ -229,6 +267,8 @@ class TestSlackAdapter:
         )
 
         await slack_adapter.ask(mock_request)
+
+        time.sleep(1)
 
         mock_chatbot.generate_response.assert_called_once_with(
             query='<@U12345678> asked: \n\n"Explain quantum computing" '


### PR DESCRIPTION
Previously, when the time taken to generate a response for a question is longer than 2 seconds, Slack throws an error even though the correct response will be provided seconds later. This is bad user experience and can confuse users.

To solve this, in this PR I implemented a messaging pattern called the Asynchronous Request-Reply pattern. This pattern is used when a client needs a response immediately but the server has a long-running process to execute so the process is done in the background instead and the server responds immediately. Once the process is completed, the server sends a response to the client via webhook. Alternatively, this pattern can also be done through polling by the client.

In this PR, I implemented this pattern by offloading the response generation execution in a different thread and immediately responding to Slack with a generic loading message, indicating the question is being processed. Once the response generation thread is complete, the response is then sent to Slack, replacing the generic loading message with the actual response.

Here are a few references about the pattern and other messaging patterns:

https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply
https://learn.microsoft.com/en-us/azure/architecture/patterns/category/messaging