### PR TITLE
Add Try Except for PDF Processing

### DIFF
--- a/rag/parsing/parsing_pdf.py
+++ b/rag/parsing/parsing_pdf.py
@@ -13,10 +13,16 @@ class PDFProcessor(FileProcessor):
         self.splitting_parser = SentenceSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
 
     def load_document(self):
-        return self.pdf_reader.load_data(file=self.document_path)
+        try:
+            return self.pdf_reader.load_data(file=self.document_path)
+        except Exception as e:
+            raise RuntimeError(f"Failed to load document: {str(e)}")
 
     def get_nodes(self, documents):
-        return self.splitting_parser.get_nodes_from_documents(documents=documents)
+        try:
+            return self.splitting_parser.get_nodes_from_documents(documents=documents)
+        except Exception as e:
+            raise RuntimeError(f"Failed to get nodes from documents: {str(e)}")
 
     def process(self):
         documents = self.load_document()

--- a/rag/parsing/test_pdf.py
+++ b/rag/parsing/test_pdf.py
@@ -50,3 +50,19 @@ def test_process(mock_pdf_reader, mock_sentence_splitter):
     assert result == ["Mocked Node"]
     mock_pdf_reader.load_data.assert_called_once_with(file=Path("dummy_path"))
     mock_sentence_splitter.get_nodes_from_documents.assert_called_once_with(documents=["Mocked Document Content"])
+    
+def test_load_document_exception(mock_pdf_reader):
+    """Test the load_document method when an exception is raised."""
+    mock_pdf_reader.load_data.side_effect = Exception("PDF loading error")
+    processor = PDFProcessor("dummy_path")
+    with pytest.raises(RuntimeError, match="Failed to load document: PDF loading error"):
+        processor.load_document()
+
+def test_get_nodes_exception(mock_sentence_splitter):
+    """Test the get_nodes method when an exception is raised."""
+    mock_sentence_splitter.get_nodes_from_documents.side_effect = Exception("Node extraction error")
+    processor = PDFProcessor("dummy_path")
+    documents = ["Mocked Document Content"]
+    with pytest.raises(RuntimeError, match="Failed to get nodes from documents: Node extraction error"):
+        processor.get_nodes(documents)
+


### PR DESCRIPTION
**Overview**
This merge request introduces error handling for the PDF processing workflow by adding try-except blocks to handle potential exceptions in document loading and node extraction. This ensures more robust error management and improves the overall reliability of the PDFProcessor.

**Changes Made**

- Added try-except blocks: Implemented error handling in the load_document and get_nodes methods to catch and raise descriptive exceptions in case of errors.

- Updated tests: Added unit tests to verify the proper handling of exceptions during PDF loading and node extraction.

- Ensured consistent behavior: The processor now throws clear runtime errors when either the document fails to load or the nodes fail to be generated.