### PR TITLE
Enhance Chatbot with Thread History Handling and Tests

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -201,6 +201,8 @@ class SlackAdapter:
         for i, message in enumerate(all_messages):
             if i == 0:
                 question = self.extract_question(message, INTRODUCTION_KEY_WORD)
+                if(question == None):
+                    continue
                 if question:
                     result.append({"role": "user", "content": question})
             else:

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -196,23 +196,25 @@ class SlackAdapter:
         )["messages"]
         
         result = []
-        for i in range(len(all_messages)):
-            message = all_messages[i]
+        INTRODUCTION_KEY_WORD = "asked:"
+
+        for i, message in enumerate(all_messages):
             if i == 0:
-                if 'text' in message and "asked:" in message['text']:
-                    question_start = message['text'].find("asked:") + len("asked:") + 1  
-                    question = message['text'][question_start:].strip().strip('"')
-                    result.append({"role" : "user", "content" : question})
+                question = self.extract_question(message, INTRODUCTION_KEY_WORD)
+                if question:
+                    result.append({"role": "user", "content": question})
             else:
-                if 'text' in message:
-                    if 'bot_id' in message:
-                        result.append({"role" : "assistant", "content" : message['text']})
-                    else:
-                        result.append({"role" : "user", "content" : message['text']})
-                
+                self.add_message_to_result(message, result)
+        
         return result
 
+    def extract_question(self, message, key_word):
+        if 'text' in message and key_word in message['text']:
+            question_start = message['text'].find(key_word) + len(key_word) + 1
+            return message['text'][question_start:].strip().strip('"')
+        return None
 
-
-            
-
+    def add_message_to_result(self, message, result):
+        if 'text' in message:
+            role = "assistant" if 'bot_id' in message else "user"
+            result.append({"role": role, "content": message['text']})

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -85,7 +85,7 @@ class TestSlackAdapter:
         )
         return mock_request
     
-    def common_message_history(self):
+    def common_chat_history(self):
         return {
             "messages": [
                 {
@@ -611,7 +611,7 @@ class TestSlackAdapter:
             "thread_ts": "1234567890.123456"
         }
 
-        mock_conversation_replies = self.common_message_history()
+        mock_conversation_replies = self.common_chat_history()
         
         mock_app.client.conversations_replies.return_value = mock_conversation_replies
 

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -672,12 +672,41 @@ class TestSlackAdapter:
             assert response.status_code == 200
     
     def test_fail_extract_question(self, mock_slack_adapter):
-        _, _, _, slack_adapter = mock_slack_adapter
-        result = slack_adapter.extract_question(        
-            message = {"text": "<@U07MKR1082Y> \n\n\"What is the weather today?\""},
-            key_word = "asked:"
-        )
-        assert result == None
+        mock_app, _, _, slack_adapter = mock_slack_adapter
+
+        event = {
+            "channel": "C12345678",
+            "thread_ts": "1234567890.123456"
+        }
+
+        mock_conversation_replies = {
+            "messages": [
+                {
+                    "text": "<@U07MKR1082Y> sked: \n\n\"What is the weather today?\"",
+                    "user": "U07QCQ3LXDW",
+                    "ts": "1234567890.123456"
+                },
+                {
+                    "text": "It's sunny!",
+                    "user": "U07QCQ3LXDW",
+                    "bot_id": "B07PM4SPSPP",
+                    "ts": "1234567890.123457"
+                },
+                {
+                    "text": "Thanks!",
+                    "user": "U07QCQ3LXDW",
+                    "ts": "1234567890.123458"
+                }
+            ]
+        }
+        
+        mock_app.client.conversations_replies.return_value = mock_conversation_replies
+
+        result = slack_adapter.get_chat_history(event)
+        assert result == [            
+            {"role": "assistant", "content": "It's sunny!"},
+            {"role": "user", "content": "Thanks!"},
+        ]
         
 
 

--- a/chat/engine.py
+++ b/chat/engine.py
@@ -22,11 +22,11 @@ class ChatEngine(ABC):
 
         full_input = f"Given a context: {context}\n Given a query: {query}\n Please answer query based on the given context." if context else query
 
-        self.history.append({"role": "user", "content": full_input})
+        self.add_chat_history("user", full_input)
 
         try:
             assistant_response = self._api_call(full_input)
-            self.history.append({"role": "assistant", "content": assistant_response})
+            self.add_chat_history("assistant", assistant_response)
             return assistant_response
         except Exception as e:
             raise ChatResponseGenerationError(f"Error generating response: {str(e)}")
@@ -34,3 +34,8 @@ class ChatEngine(ABC):
     def reset_history(self):
         """Reset the chat history."""
         self.history = [self._get_generate_system()]
+        
+    def add_chat_history(self, role, content):
+        """Add chat history."""
+        self.history.append({"role" : role, "content" : content})
+


### PR DESCRIPTION
### **Description:**
This PR adds the ability for the chatbot to retain and utilize chat history within Slack reply threads, enabling context-aware responses. Additionally, it includes tests to verify this functionality.

### **Key Changes:**
- **Retain Chat History:** Implemented chat history handling in reply threads, classifying messages as "user" or "assistant" for contextual responses.
- **Automated Testing:** Added unit tests to validate correct processing of chat history and ensure accurate responses