### PR TITLE
[SPN-34, SPN-35] Implement ask command using Block Kit

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -81,6 +81,56 @@ class SlackAdapter:
                 text="Something went wrong when trying to generate your response.",
             )
 
+    async def ask_form(self, request: Request):
+        return {
+            "blocks": [
+                {
+                    "type": "section",
+                    "block_id": "bots",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Select the chatbot you want to ask*",
+                    },
+                    "accessory": {
+                        "action_id": "select_chatbot",
+                        "type": "external_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Select a chatbot",
+                        },
+                        "min_query_length": 0,
+                    },
+                },
+                {
+                    "type": "input",
+                    "block_id": "question",
+                    "element": {
+                        "action_id": "question",
+                        "type": "plain_text_input",
+                        "multiline": True,
+                        "min_length": 1,
+                    },
+                    "label": {"type": "plain_text", "text": "What is your question?"},
+                    "hint": {
+                        "type": "plain_text",
+                        "text": "e.g. Who's the CEO of our company?",
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Ask question"},
+                            "style": "primary",
+                            "value": "ask_question",
+                            "action_id": "ask_question",
+                        },
+                    ],
+                },
+            ]
+        }
+
     async def ask(self, request: Request):
         data = await request.form()
 

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -139,7 +139,7 @@ class SlackAdapter:
                 text="Something went wrong when trying to generate your response.",
             )
 
-    async def ask_form(self, _: Request):
+    def ask_form(self, _: Request):
         return {
             "blocks": [
                 {

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -41,18 +41,17 @@ class SlackAdapter:
         payload = json.loads(payload_str)
 
         actions = payload["actions"]
-        if len(actions) == 1:
-            if actions[0]["action_id"] == "ask_question":
-                channel_id = payload["channel"]["id"]
-                user_id = payload["user"]["id"]
-                slug = payload["state"]["values"]["bots"]["select_chatbot"][
-                    "selected_option"
-                ]["value"]
-                question = payload["state"]["values"]["question"]["question"]["value"]
+        if len(actions) == 1 and actions[0]["action_id"] == "ask_question":
+            channel_id = payload["channel"]["id"]
+            user_id = payload["user"]["id"]
+            slug = payload["state"]["values"]["bots"]["select_chatbot"][
+                "selected_option"
+            ]["value"]
+            question = payload["state"]["values"]["question"]["question"]["value"]
 
-                await self.ask_v2(
-                    channel_id=channel_id, user_id=user_id, slug=slug, question=question
-                )
+            await self.ask_v2(
+                channel_id=channel_id, user_id=user_id, slug=slug, question=question
+            )
 
         return Response(status_code=200)
 
@@ -103,7 +102,7 @@ class SlackAdapter:
                 text="Something went wrong when trying to generate your response.",
             )
 
-    async def ask_form(self, request: Request):
+    async def ask_form(self, _: Request):
         return {
             "blocks": [
                 {

--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -14,7 +14,7 @@ from chat import ChatEngineSelector, ChatEngine
 from chat.exceptions import ChatResponseGenerationError
 
 
-class UnableToRespondToInteraction(BaseException):
+class UnableToRespondToInteraction(Exception):
     pass
 
 

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import time
 from unittest.mock import AsyncMock, MagicMock, patch, call
@@ -12,7 +13,6 @@ from bot.helper import relative_time
 from chat import ChatEngineSelector, ChatOpenAI
 from chat.exceptions import ChatResponseGenerationError
 from bot.repository import BotModel
-
 
 
 class TestSlackAdapter:
@@ -75,37 +75,71 @@ class TestSlackAdapter:
                 "channel_id": "C12345678",
                 "user_id": "U12345678",
                 "text": text,
-                "metadata" : {
+                "metadata": {
                     "event_type": "chat-data",
-                    "event_payload": {
-                        "bot_slug": "12"
-                    }
-                }
+                    "event_payload": {"bot_slug": "12"},
+                },
             }
         )
         return mock_request
-    
+
     def common_chat_history(self):
         return {
             "messages": [
                 {
-                    "text": "<@U07MKR1082Y> asked: \n\n\"What is the weather today?\"",
+                    "text": '<@U07MKR1082Y> asked: \n\n"What is the weather today?"',
                     "user": "U07QCQ3LXDW",
-                    "ts": "1234567890.123456"
+                    "ts": "1234567890.123456",
                 },
                 {
                     "text": "It's sunny!",
                     "user": "U07QCQ3LXDW",
                     "bot_id": "B07PM4SPSPP",
-                    "ts": "1234567890.123457"
+                    "ts": "1234567890.123457",
                 },
-                {
-                    "text": "Thanks!",
-                    "user": "U07QCQ3LXDW",
-                    "ts": "1234567890.123458"
-                }
+                {"text": "Thanks!", "user": "U07QCQ3LXDW", "ts": "1234567890.123458"},
             ]
         }
+
+    async def mock_select_chatbot_options_request(self, mock_request):
+        mock_request.form = AsyncMock(
+            return_value={
+                "channel_id": "C12345678",
+                "user_id": "U12345678",
+                "payload": json.dumps(
+                    {
+                        "type": "block_suggestion",
+                        "action_id": "select_chatbot",
+                        "block_id": "bots",
+                        "value": "",
+                    }
+                ),
+            }
+        )
+        return mock_request
+
+    @pytest.mark.asyncio
+    async def test_load_options_select_chatbot(
+        self,
+        mock_slack_adapter,
+        mock_bot_response_list,
+        mock_request,
+    ):
+        _, _, mock_bot_service, slack_adapter = mock_slack_adapter
+        _, _, mock_bot_list = mock_bot_response_list
+
+        bots = mock_bot_list.return_value
+
+        mock_request = await self.mock_select_chatbot_options_request(mock_request)
+        mock_bot_service.get_chatbots = mock_bot_list
+
+        res = await slack_adapter.load_options(mock_request)
+        options = res["options"]
+
+        assert len(bots) == len(options)
+
+        for i in range(len(options)):
+            assert options[i]["value"] == bots[i].slug
 
     @pytest.mark.asyncio
     async def test_send_generated_response(self, mock_slack_adapter):
@@ -114,9 +148,7 @@ class TestSlackAdapter:
         mock_app.client.chat_postMessage = MagicMock(
             side_effect=[{"ts": "1234567890.123456"}, {"ts": "1234567890.654321"}]
         )
-        mock_chatbot.generate_response = MagicMock(
-            return_value="I'm fine, thank you!"
-        )
+        mock_chatbot.generate_response = MagicMock(return_value="I'm fine, thank you!")
 
         slack_adapter.send_generated_response(
             "C12345678", "1234567890.654321", mock_chatbot, "How are you?"
@@ -160,27 +192,22 @@ class TestSlackAdapter:
         mock_chatbot.generate_response = MagicMock(
             return_value="Chatbot Reply: I'm fine, thank you!"
         )
-        
+
         slack_adapter.process_chatbot_request = AsyncMock(
             return_value=Response(status_code=200)
         )
 
         mock_request = await self.common_mock_request(mock_request, "12 How are you?")
-        
+
         response = await slack_adapter.ask(mock_request)
 
         mock_app.client.chat_postMessage.assert_called_once_with(
             channel="C12345678",
             text='<@U12345678> asked: \n\n"How are you?" ',
-            metadata={
-                "event_type": "chat-data",
-                "event_payload": {
-                    "bot_slug": "12"
-                }
-            }
+            metadata={"event_type": "chat-data", "event_payload": {"bot_slug": "12"}},
         )
         assert response.status_code == 200
-        
+
     @pytest.mark.asyncio
     async def test_ask_method_slack_api_error(self, mock_slack_adapter, mock_request):
         mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
@@ -192,13 +219,13 @@ class TestSlackAdapter:
         mock_chatbot.generate_response = MagicMock(
             return_value="Chatbot Reply: I'm fine, thank you!"
         )
-        
+
         slack_adapter.process_chatbot_request = AsyncMock(
             return_value=Response(status_code=200)
         )
 
         mock_request = await self.common_mock_request(mock_request, "12 How are you?")
-        
+
         with pytest.raises(HTTPException) as exc_info:
             await slack_adapter.ask(mock_request)
 
@@ -208,12 +235,7 @@ class TestSlackAdapter:
         mock_app.client.chat_postMessage.assert_called_once_with(
             channel="C12345678",
             text='<@U12345678> asked: \n\n"How are you?" ',
-            metadata={
-                "event_type": "chat-data",
-                "event_payload": {
-                    "bot_slug": "12"
-                }
-            }
+            metadata={"event_type": "chat-data", "event_payload": {"bot_slug": "12"}},
         )
 
     @pytest.mark.asyncio
@@ -305,14 +327,9 @@ class TestSlackAdapter:
         )
         assert mock_app.client.chat_postMessage.call_count == 2
         mock_app.client.chat_postMessage.assert_any_call(
-            channel="C12345678", 
+            channel="C12345678",
             text='<@U12345678> asked: \n\n"How is the weather?" ',
-            metadata={
-                "event_type": "chat-data",
-                "event_payload": {
-                    "bot_slug": "12"
-                }
-            }
+            metadata={"event_type": "chat-data", "event_payload": {"bot_slug": "12"}},
         )
         mock_app.client.chat_update.assert_called_once_with(
             channel="C12345678", ts="1234567890.123456", text="Chatbot Response: Hello!"
@@ -343,7 +360,7 @@ class TestSlackAdapter:
         mock_app.client.chat_postMessage = MagicMock(
             return_value={"ts": "1234567890.123456"}
         )
-        
+
         mock_chatbot.generate_response = MagicMock(
             return_value="I'm not sure how to answer that."
         )
@@ -363,12 +380,7 @@ class TestSlackAdapter:
         mock_app.client.chat_postMessage.assert_any_call(
             channel="C12345678",
             text='<@U12345678> asked: \n\n"Explain quantum computing" ',
-            metadata={
-                "event_type": "chat-data",
-                "event_payload": {
-                    "bot_slug": "12"
-                }
-            }
+            metadata={"event_type": "chat-data", "event_payload": {"bot_slug": "12"}},
         )
         mock_app.client.chat_update.assert_called_once_with(
             channel="C12345678",
@@ -445,16 +457,16 @@ class TestSlackAdapter:
         assert excinfo.value.status_code == 400
         assert "Slack API Error" in excinfo.value.detail
         assert mock_app.client.chat_postMessage.call_count == 1
-    
+
     def test_event_message_without_thread(self, mock_slack_adapter):
         _, _, _, slack_adapter = mock_slack_adapter
-        
+
         event = {
             "type": "message",
             "channel": "C123ABC456",
             "user": "U123ABC456",
             "text": "Hello world",
-            "ts": "1355517523.000005"
+            "ts": "1355517523.000005",
         }
 
         slack_adapter.event_message_replied = MagicMock()
@@ -462,10 +474,10 @@ class TestSlackAdapter:
         slack_adapter.event_message(event)
 
         slack_adapter.event_message_replied.assert_not_called()
-        
+
     def test_event_message_with_thread_wrong_user(self, mock_slack_adapter):
         _, _, _, slack_adapter = mock_slack_adapter
-        
+
         event = {"thread_ts": "1355517523.000005", "channel": "C123ABC456"}
 
         slack_adapter.app.client.conversations_history.return_value = {
@@ -482,7 +494,7 @@ class TestSlackAdapter:
 
     def test_event_message_with_thread_wrong_parent_message(self, mock_slack_adapter):
         _, _, _, slack_adapter = mock_slack_adapter
-        
+
         event = {"thread_ts": "1355517523.000005", "channel": "C123ABC456"}
 
         slack_adapter.app.client.conversations_history.return_value = {
@@ -499,120 +511,127 @@ class TestSlackAdapter:
 
     def test_event_message_with_thread_bot_replied(self, mock_slack_adapter):
         mock_app, _, _, slack_adapter = mock_slack_adapter
-        
-        event = {"thread_ts": "1355517523.000005", 
-                 "channel": "C123ABC456",
-                 "text" : "How are you?"}
-        
+
+        event = {
+            "thread_ts": "1355517523.000005",
+            "channel": "C123ABC456",
+            "text": "How are you?",
+        }
+
         parent_messages = {
             "messages": [
                 {
-                    "user": slack_adapter.app_user_id, 
+                    "user": slack_adapter.app_user_id,
                     "text": '<@U07N64EUJ8Y> asked:\n\n"hello"',
-                    "metadata" : {
-                        "event_payload" : {
-                            "bot_slug" : 12
-                        }
-                    }
+                    "metadata": {"event_payload": {"bot_slug": 12}},
                 }
             ]
         }
-        
+
         slack_adapter.bot_replied = MagicMock()
 
         slack_adapter.app.client.conversations_history.return_value = parent_messages
-        
+
         slack_adapter.event_message_replied(event)
-        
+
         mock_app.client.conversations_history.assert_called_once_with(
             channel="C123ABC456",
             inclusive=True,
             oldest="1355517523.000005",
             limit=1,
-            include_all_metadata=True
+            include_all_metadata=True,
         )
-        
-        slack_adapter.bot_replied.assert_called_once_with(event, mock_app.client.conversations_history.return_value)
+
+        slack_adapter.bot_replied.assert_called_once_with(
+            event, mock_app.client.conversations_history.return_value
+        )
 
     def test_bot_replied(self, mock_slack_adapter):
         _, mock_chatbot, _, slack_adapter = mock_slack_adapter
-        
-        event = {"thread_ts": "1355517523.000005", 
-                 "channel": "C123ABC456",
-                 "text" : "How are you?"}
-        
+
+        event = {
+            "thread_ts": "1355517523.000005",
+            "channel": "C123ABC456",
+            "text": "How are you?",
+        }
+
         parent_messages = {
             "messages": [
                 {
-                    "user": slack_adapter.app_user_id, 
+                    "user": slack_adapter.app_user_id,
                     "text": '<@U07N64EUJ8Y> asked:\n\n"hello"',
-                    "metadata" : {
-                        "event_payload" : {
-                            "bot_slug" : "test-bot"
-                        }
-                    }
+                    "metadata": {"event_payload": {"bot_slug": "test-bot"}},
                 }
             ]
         }
 
-        slack_adapter.bot_service.get_chatbot_by_slug = MagicMock(return_value=mock_chatbot)
+        slack_adapter.bot_service.get_chatbot_by_slug = MagicMock(
+            return_value=mock_chatbot
+        )
 
-        slack_adapter.process_chatbot_request = AsyncMock(return_value={"status_code": 200})
+        slack_adapter.process_chatbot_request = AsyncMock(
+            return_value={"status_code": 200}
+        )
 
-        slack_adapter.get_chat_history = MagicMock(return_value=[
-            {"role" : "user", "content" : "How are you ?"},
-            {"role" : "assistant", "content" : "Fine"}
-        ])
+        slack_adapter.get_chat_history = MagicMock(
+            return_value=[
+                {"role": "user", "content": "How are you ?"},
+                {"role": "assistant", "content": "Fine"},
+            ]
+        )
 
         response = slack_adapter.bot_replied(event, parent_messages)
 
-        slack_adapter.bot_service.get_chatbot_by_slug.assert_called_once_with(slug="test-bot")
+        slack_adapter.bot_service.get_chatbot_by_slug.assert_called_once_with(
+            slug="test-bot"
+        )
         slack_adapter.process_chatbot_request.assert_called_once_with(
-            mock_chatbot, "How are you?", "C123ABC456", "1355517523.000005", 
+            mock_chatbot,
+            "How are you?",
+            "C123ABC456",
+            "1355517523.000005",
             [
-                {"role" : "user", "content" : "How are you ?"},
-                {"role" : "assistant", "content" : "Fine"}
+                {"role": "user", "content": "How are you ?"},
+                {"role": "assistant", "content": "Fine"},
             ],
         )
         assert response == {"status_code": 200}
-        
-        
+
     def test_bot_replied_chatbot_not_found(self, mock_slack_adapter):
         _, _, _, slack_adapter = mock_slack_adapter
 
         slack_adapter.bot_service.get_chatbot_by_slug = MagicMock(return_value=None)
 
-        event = {"thread_ts": "1355517523.000005", 
-                 "channel": "C123ABC456",
-                 "text" : "How are you?"}
+        event = {
+            "thread_ts": "1355517523.000005",
+            "channel": "C123ABC456",
+            "text": "How are you?",
+        }
         parent_messages = {
             "messages": [
                 {
-                    "user": slack_adapter.app_user_id, 
+                    "user": slack_adapter.app_user_id,
                     "text": '<@U07N64EUJ8Y> asked:\n\n"hello"',
-                    "metadata" : {
-                        "event_payload" : {
-                            "bot_slug" : "non-existent-bot"
-                        }
-                    }
+                    "metadata": {"event_payload": {"bot_slug": "non-existent-bot"}},
                 }
             ]
         }
         response = slack_adapter.bot_replied(event, parent_messages)
 
-        slack_adapter.bot_service.get_chatbot_by_slug.assert_called_once_with(slug="non-existent-bot")
-        assert response == {"text": "Whoops. Can't find the chatbot you're looking for."}
-        
+        slack_adapter.bot_service.get_chatbot_by_slug.assert_called_once_with(
+            slug="non-existent-bot"
+        )
+        assert response == {
+            "text": "Whoops. Can't find the chatbot you're looking for."
+        }
+
     def test_get_chat_history(self, mock_slack_adapter):
         mock_app, _, _, slack_adapter = mock_slack_adapter
 
-        event = {
-            "channel": "C12345678",
-            "thread_ts": "1234567890.123456"
-        }
+        event = {"channel": "C12345678", "thread_ts": "1234567890.123456"}
 
         mock_conversation_replies = self.common_chat_history()
-        
+
         mock_app.client.conversations_replies.return_value = mock_conversation_replies
 
         result = slack_adapter.get_chat_history(event)
@@ -620,7 +639,7 @@ class TestSlackAdapter:
         expected_result = [
             {"role": "user", "content": "What is the weather today?"},
             {"role": "assistant", "content": "It's sunny!"},
-            {"role": "user", "content": "Thanks!"}
+            {"role": "user", "content": "Thanks!"},
         ]
 
         assert result == expected_result
@@ -628,8 +647,9 @@ class TestSlackAdapter:
             channel="C12345678",
             inclusive=True,
             ts="1234567890.123456",
-            include_all_metadata=True
+            include_all_metadata=True,
         )
+
     @pytest.mark.asyncio
     async def test_process_chatbot_request_with_history(self, mock_slack_adapter):
         mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
@@ -642,14 +662,16 @@ class TestSlackAdapter:
             {"role": "user", "content": "1 + 1 ?"},
             {"role": "assistant", "content": "1 + 1 = 2"},
         ]
-        
-        mock_app.client.chat_postMessage = MagicMock(return_value={"ts": "1234567890.654321"})
-        
+
+        mock_app.client.chat_postMessage = MagicMock(
+            return_value={"ts": "1234567890.654321"}
+        )
+
         mock_chatbot.add_chat_history = MagicMock()
-        
+
         bot = BotModel()
         bot.model = ChatOpenAI()
-        
+
         with patch("threading.Thread") as mock_thread:
             response = await slack_adapter.process_chatbot_request(
                 chatbot=bot,
@@ -664,49 +686,43 @@ class TestSlackAdapter:
                 text=":hourglass_flowing_sand: Processing your request, please wait...",
                 thread_ts=thread_ts,
             )
-            
-            expected_calls = [call(event["role"], event["content"]) for event in history]
-            mock_chatbot.add_chat_history.assert_has_calls(expected_calls, any_order=False)
+
+            expected_calls = [
+                call(event["role"], event["content"]) for event in history
+            ]
+            mock_chatbot.add_chat_history.assert_has_calls(
+                expected_calls, any_order=False
+            )
 
             mock_thread.assert_called_once()
             assert response.status_code == 200
-    
+
     def test_fail_extract_question(self, mock_slack_adapter):
         mock_app, _, _, slack_adapter = mock_slack_adapter
 
-        event = {
-            "channel": "C12345678",
-            "thread_ts": "1234567890.123456"
-        }
+        event = {"channel": "C12345678", "thread_ts": "1234567890.123456"}
 
         mock_conversation_replies = {
             "messages": [
                 {
-                    "text": "<@U07MKR1082Y> sked: \n\n\"What is the weather today?\"",
+                    "text": '<@U07MKR1082Y> sked: \n\n"What is the weather today?"',
                     "user": "U07QCQ3LXDW",
-                    "ts": "1234567890.123456"
+                    "ts": "1234567890.123456",
                 },
                 {
                     "text": "It's sunny!",
                     "user": "U07QCQ3LXDW",
                     "bot_id": "B07PM4SPSPP",
-                    "ts": "1234567890.123457"
+                    "ts": "1234567890.123457",
                 },
-                {
-                    "text": "Thanks!",
-                    "user": "U07QCQ3LXDW",
-                    "ts": "1234567890.123458"
-                }
+                {"text": "Thanks!", "user": "U07QCQ3LXDW", "ts": "1234567890.123458"},
             ]
         }
-        
+
         mock_app.client.conversations_replies.return_value = mock_conversation_replies
 
         result = slack_adapter.get_chat_history(event)
-        assert result == [            
+        assert result == [
             {"role": "assistant", "content": "It's sunny!"},
             {"role": "user", "content": "Thanks!"},
         ]
-        
-
-

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -200,7 +200,7 @@ class TestSlackAdapter:
         mock_slack_adapter,
         mock_request,
     ):
-        _, _, mock_bot_service, slack_adapter = mock_slack_adapter
+        _, _, _, slack_adapter = mock_slack_adapter
 
         mock_request = await self.mock_load_options_request(
             mock_request, action_id="unknown"

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -142,6 +142,20 @@ class TestSlackAdapter:
             assert options[i]["value"] == bots[i].slug
 
     @pytest.mark.asyncio
+    async def test_ask_form(
+        self,
+        mock_slack_adapter,
+        mock_request,
+    ):
+        _, _, _, slack_adapter = mock_slack_adapter
+
+        mock_request = await self.common_mock_request(mock_request, "12 What")
+
+        res = await slack_adapter.ask_form(mock_request)
+
+        assert res["blocks"] is not None
+
+    @pytest.mark.asyncio
     async def test_send_generated_response(self, mock_slack_adapter):
         mock_app, mock_chatbot, _, slack_adapter = mock_slack_adapter
 

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -345,7 +345,7 @@ class TestSlackAdapter:
 
         mock_request = await self.common_mock_request(mock_request, "12 What")
 
-        res = await slack_adapter.ask_form(mock_request)
+        res = slack_adapter.ask_form(mock_request)
 
         assert res["blocks"] is not None
 

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -328,7 +328,7 @@ class TestSlackAdapter:
         )
 
     @pytest.mark.asyncio
-    async def test_as_v2_no_bots(self, mock_slack_adapter):
+    async def test_ask_v2_no_bots(self, mock_slack_adapter):
         mock_app, _, mock_bot_service, slack_adapter = mock_slack_adapter
 
         mock_app.client.chat_postMessage = MagicMock(

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -82,6 +82,36 @@ class TestSlackAdapter:
     def mock_response(self):
         return MagicMock(spec=requests.Response)
 
+    def mock_interaction_form(self):
+        return {
+            "payload": json.dumps(
+                {
+                    "channel": {
+                        "id": "C12345678",
+                    },
+                    "user": {
+                        "id": "U12345678",
+                    },
+                    "state": {
+                        "values": {
+                            "bots": {
+                                "select_chatbot": {"selected_option": {"value": "12"}}
+                            },
+                            "question": {
+                                "question": {"value": "What is the weather today?"}
+                            },
+                        },
+                    },
+                    "actions": [
+                        {
+                            "action_id": "ask_question",
+                        }
+                    ],
+                    "response_url": "https://hooks.slack.com/XXXXXXX",
+                }
+            )
+        }
+
     async def common_mock_request(self, mock_request, text):
         mock_request.form = AsyncMock(
             return_value={
@@ -141,38 +171,7 @@ class TestSlackAdapter:
     ):
         _, _, _, slack_adapter = mock_slack_adapter
 
-        mock_request.form = AsyncMock(
-            return_value={
-                "payload": json.dumps(
-                    {
-                        "channel": {
-                            "id": "C12345678",
-                        },
-                        "user": {
-                            "id": "U12345678",
-                        },
-                        "state": {
-                            "values": {
-                                "bots": {
-                                    "select_chatbot": {
-                                        "selected_option": {"value": "12"}
-                                    }
-                                },
-                                "question": {
-                                    "question": {"value": "What is the weather today?"}
-                                },
-                            },
-                        },
-                        "actions": [
-                            {
-                                "action_id": "ask_question",
-                            }
-                        ],
-                        "response_url": "https://hooks.slack.com/XXXXXXX",
-                    }
-                )
-            }
-        )
+        mock_request.form = AsyncMock(return_value=self.mock_interaction_form())
 
         slack_adapter.ask_v2 = AsyncMock()
 
@@ -198,38 +197,7 @@ class TestSlackAdapter:
     ):
         _, _, _, slack_adapter = mock_slack_adapter
 
-        mock_request.form = AsyncMock(
-            return_value={
-                "payload": json.dumps(
-                    {
-                        "channel": {
-                            "id": "C12345678",
-                        },
-                        "user": {
-                            "id": "U12345678",
-                        },
-                        "state": {
-                            "values": {
-                                "bots": {
-                                    "select_chatbot": {
-                                        "selected_option": {"value": "12"}
-                                    }
-                                },
-                                "question": {
-                                    "question": {"value": "What is the weather today?"}
-                                },
-                            },
-                        },
-                        "actions": [
-                            {
-                                "action_id": "ask_question",
-                            }
-                        ],
-                        "response_url": "https://hooks.slack.com/XXXXXXX",
-                    }
-                )
-            }
-        )
+        mock_request.form = AsyncMock(return_value=self.mock_interaction_form())
 
         slack_adapter.ask_v2 = AsyncMock(side_effect=EmptyQuestion)
         with pytest.raises(HTTPException) as e:
@@ -251,38 +219,7 @@ class TestSlackAdapter:
     ):
         _, _, _, slack_adapter = mock_slack_adapter
 
-        mock_request.form = AsyncMock(
-            return_value={
-                "payload": json.dumps(
-                    {
-                        "channel": {
-                            "id": "C12345678",
-                        },
-                        "user": {
-                            "id": "U12345678",
-                        },
-                        "state": {
-                            "values": {
-                                "bots": {
-                                    "select_chatbot": {
-                                        "selected_option": {"value": "12"}
-                                    }
-                                },
-                                "question": {
-                                    "question": {"value": "What is the weather today?"}
-                                },
-                            },
-                        },
-                        "actions": [
-                            {
-                                "action_id": "ask_question",
-                            }
-                        ],
-                        "response_url": "https://hooks.slack.com/XXXXXXX",
-                    }
-                )
-            }
-        )
+        mock_request.form = AsyncMock(return_value=self.mock_interaction_form())
 
         slack_adapter.ask_v2 = AsyncMock()
 


### PR DESCRIPTION
This PR implements a second version of the ask command feature but with a user-friendly form built with Block Kit. Improvements made:

- Users no longer have to manually type or copy+paste a bot slug to ask a question
- Users can select the bot it wants directly in the form via a dropdown

The screenshot of the form can be seen below

![new_form](https://github.com/user-attachments/assets/a93d0e26-62b0-4503-84c7-6d0d525090f1)

