### PR TITLE
[SAP-17] Design reaction events schema

### DIFF
--- a/migrations/20241111020516_create_reaction_events.sql
+++ b/migrations/20241111020516_create_reaction_events.sql
@@ -1,0 +1,4 @@
+-- Create enum type "reactions"
+CREATE TYPE "public"."reactions" AS ENUM ('POSITIVE', 'NEGATIVE');
+-- Create "reaction_events" table
+CREATE TABLE "public"."reaction_events" ("id" uuid NOT NULL, "bot_id" uuid NOT NULL, "reaction" "public"."reactions" NOT NULL, "source_adapter" "public"."message_adapters" NOT NULL, "source_adapter_message_id" character varying(255) NOT NULL, "source_adapter_user_id" character varying(255) NOT NULL, "message" text NOT NULL, "created_at" timestamptz NULL DEFAULT now(), PRIMARY KEY ("id"));

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XhP1YnDElsSQg9jANrAd9G4d/ue3TfqYMrRdhR/ZSU4=
+h1:i/IbXrmsm3c/Br4Nz+TAtTgP3tC9GIUZqLxh+et37wY=
 20240923095223_create_bots.sql h1:b+ptk5RBZ/UlKGp9lfjOmVwsitN804Qsncs4VSdVBbs=
 20240925055750_add_bot_message_adapter_column.sql h1:kC0ahrjuFiHEEqSDaIv531y4QwP5Q1bN19mchJs8Dcs=
 20241010142723_add_slug_field_and_anthropic_enum.sql h1:qQH6hJF3QlCveiUxKVv0YNjxnNnMx3B5rftMwMbatQo=
@@ -6,3 +6,4 @@ h1:XhP1YnDElsSQg9jANrAd9G4d/ue3TfqYMrRdhR/ZSU4=
 20241024142433_add_bots_fk_to_users.sql h1:w/ZabwORGBjekEj0tr2F772xD/Mp9EeEsnUKuU6cru0=
 20241108065550_add_access_level_to_users.sql h1:PmZWbZeOZrc++kgxYK59RDH7Dzvm6QAmOy/3Z28fNq0=
 20241110193900_add_data_source.sql h1:rUJDvVgnfyssOSoqEfYn4T94CUSNusxiMfa6ctbzWBk=
+20241111020516_create_reaction_events.sql h1:mPdA6ApSj4YBrMJDg7IkrUDG/3c75QmVQXKHJlDVw4A=

--- a/schema.sql
+++ b/schema.sql
@@ -6,6 +6,8 @@ CREATE TYPE login_methods AS ENUM('GOOGLE');
 
 CREATE TYPE document_type AS ENUM ('csv', 'pdf', 'txt');
 
+CREATE TYPE reactions AS ENUM('POSITIVE', 'NEGATIVE');
+
 CREATE TABLE users (
     id UUID PRIMARY KEY,
     sub VARCHAR(127) NOT NULL,
@@ -40,4 +42,15 @@ CREATE TABLE documents (
   updated_at TIMESTAMPTZ DEFAULT NOW()
   -- created_by uuid NOT NULL, 
   -- FOREIGN KEY (created_by) REFERENCES users (id),
+);
+
+CREATE TABLE reaction_events (
+    id UUID PRIMARY KEY,
+    bot_id UUID NOT NULL, -- FK to bots(id)
+    reaction reactions NOT NULL,
+    source_adapter message_adapters NOT NULL,
+    source_adapter_message_id VARCHAR(255) NOT NULL,
+    source_adapter_user_id VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
 );


### PR DESCRIPTION
This PR adds the database schema for reaction events. The upcoming PR after this will address the handling and saving of negative reaction events using this schema for chatbot analytics