### PR TITLE
[SAP-18] Handle negative reaction events for analytics

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -1,1 +1,2 @@
 from .slack import SlackAdapter
+from .reaction_event_repository import PostgresReactionEventRepository

--- a/adapter/reaction_event.py
+++ b/adapter/reaction_event.py
@@ -1,0 +1,44 @@
+import enum
+
+from datetime import datetime
+from typing import Any
+from pydantic import BaseModel, ConfigDict, UUID4
+from bot.bot import MessageAdapter
+
+
+class UnknownReaction(Exception):
+    message = "Unknown reaction found"
+
+
+class Reaction(enum.StrEnum):
+    POSITIVE = "Positive"
+    NEGATIVE = "Negative"
+
+
+class ReactionEventCreate(BaseModel):
+    bot_id: UUID4
+    reaction: Reaction
+    source_adapter: MessageAdapter
+    source_adapter_message_id: str
+    source_adapter_user_id: str
+    message: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @staticmethod
+    def from_slack_reaction(bot_id: str, message: str, event: dict[str, Any]):
+        if event["reaction"] == "-1":
+            reaction = Reaction.NEGATIVE
+        elif event["reaction"] == "+1":
+            reaction = Reaction.POSITIVE
+        else:
+            raise UnknownReaction
+
+        return ReactionEventCreate(
+            bot_id=bot_id,
+            reaction=reaction,
+            source_adapter=MessageAdapter.SLACK,
+            source_adapter_message_id=event["item"]["ts"],
+            source_adapter_user_id=event["user"],
+            message=message,
+        )

--- a/adapter/reaction_event.py
+++ b/adapter/reaction_event.py
@@ -1,6 +1,5 @@
 import enum
 
-from datetime import datetime
 from typing import Any
 from pydantic import BaseModel, ConfigDict, UUID4
 from bot.bot import MessageAdapter

--- a/adapter/reaction_event_repository.py
+++ b/adapter/reaction_event_repository.py
@@ -1,0 +1,53 @@
+from abc import abstractmethod, ABC
+from datetime import datetime
+from loguru import logger
+from sqlalchemy import Column, Uuid, Enum, String, Text, DateTime
+from sqlalchemy.orm import sessionmaker, Session, declarative_base
+from uuid import uuid4
+
+from bot.bot import MessageAdapter
+from .reaction_event import ReactionEventCreate, Reaction
+
+Base = declarative_base()
+
+
+class ReactionEventModel(Base):
+    __tablename__ = "reaction_events"
+
+    id = Column(Uuid, primary_key=True)
+    bot_id = Column(Uuid, nullable=False)
+    reaction = Column(Enum(Reaction, validate_strings=True), nullable=False)
+    source_adapter = Column(Enum(MessageAdapter, validate_strings=True), nullable=False)
+    source_adapter_message_id = Column(String(255), nullable=False)
+    source_adapter_user_id = Column(String(255), nullable=False)
+    message = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.now)
+
+
+class ReactionEventRepository(ABC):
+    @abstractmethod
+    def create_reaction_event(self, event_create: ReactionEventCreate):
+        pass
+
+
+class PostgresReactionEventRepository(ReactionEventRepository):
+    def __init__(self, session: sessionmaker[Session]) -> None:
+        self.create_session = session
+        self.logger = logger.bind(service="PostgresReactionEventRepository")
+
+    def create_reaction_event(self, event_create: ReactionEventCreate):
+        self.logger.bind(
+            bot=event_create.bot_id,
+            reaction=event_create.reaction,
+            message_id=event_create.source_adapter_message_id,
+            adapter=event_create.source_adapter,
+        ).info("saving reaction event")
+
+        with self.create_session() as session:
+            with self.logger.catch(message="saving reaction event error", reraise=True):
+                reaction_event_id = uuid4()
+                new_reaction_event = ReactionEventModel(
+                    **event_create.model_dump(), id=reaction_event_id
+                )
+                session.add(new_reaction_event)
+                session.commit()

--- a/adapter/test_reaction_event.py
+++ b/adapter/test_reaction_event.py
@@ -1,0 +1,72 @@
+import pytest
+
+from .reaction_event import ReactionEventCreate, Reaction, UnknownReaction
+from bot.bot import MessageAdapter
+from uuid import uuid4
+
+
+class TestReactionEvent:
+    def mock_slack_reaction_added_event(self, reaction: str):
+        event = {
+            "type": "reaction_added",
+            "user": "U1234567890",
+            "reaction": reaction,
+            "item": {
+                "type": "message",
+                "channel": "C1234567890",
+                "ts": "1731075911.249209",
+            },
+            "item_user": "U9876543210",
+            "event_ts": "1731076540.000900",
+        }
+        return event
+
+    @pytest.fixture
+    def mock_slack_negative_reaction_event(self):
+        return self.mock_slack_reaction_added_event("-1")
+
+    @pytest.fixture
+    def mock_slack_positive_reaction_event(self):
+        return self.mock_slack_reaction_added_event("+1")
+
+    def test_reaction_event_create(
+        self,
+        mock_slack_negative_reaction_event,
+        mock_slack_positive_reaction_event,
+    ):
+        bot_id = uuid4()
+        message = "Hi there!"
+
+        slack_reaction_events = [
+            (mock_slack_negative_reaction_event, Reaction.NEGATIVE),
+            (mock_slack_positive_reaction_event, Reaction.POSITIVE),
+        ]
+
+        for event, expected_reaction in slack_reaction_events:
+            reaction_event_create = ReactionEventCreate.from_slack_reaction(
+                bot_id,
+                message,
+                event,
+            )
+
+            assert reaction_event_create.bot_id == bot_id
+            assert reaction_event_create.reaction == expected_reaction
+            assert reaction_event_create.source_adapter == MessageAdapter.SLACK
+            assert (
+                reaction_event_create.source_adapter_message_id == event["item"]["ts"]
+            )
+            assert reaction_event_create.source_adapter_user_id == event["user"]
+            assert reaction_event_create.message == message
+
+    def test_reaction_event_create_unknown_reaction(self):
+        bot_id = "U1234567890"
+        message = "Hi there!"
+
+        slack_reaction_event = self.mock_slack_reaction_added_event("unknown_reaction")
+
+        with pytest.raises(UnknownReaction):
+            ReactionEventCreate.from_slack_reaction(
+                bot_id,
+                message,
+                slack_reaction_event,
+            )

--- a/adapter/test_reaction_event.py
+++ b/adapter/test_reaction_event.py
@@ -44,7 +44,7 @@ class TestReactionEvent:
 
         for event, expected_reaction in slack_reaction_events:
             reaction_event_create = ReactionEventCreate.from_slack_reaction(
-                bot_id,
+                str(bot_id),
                 message,
                 event,
             )

--- a/adapter/test_reaction_event_repository.py
+++ b/adapter/test_reaction_event_repository.py
@@ -1,0 +1,52 @@
+import pytest
+
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+from uuid import uuid4
+
+from bot.bot import MessageAdapter
+from .reaction_event import ReactionEventCreate, Reaction
+from .reaction_event_repository import (
+    PostgresReactionEventRepository,
+    ReactionEventModel,
+)
+
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+
+class TestReactionEventRepository:
+    @pytest.fixture()
+    def setup_database(self):
+        """Create a test database and tables."""
+        engine = create_engine(TEST_DATABASE_URL)
+        ReactionEventModel.metadata.create_all(engine)
+        yield engine
+        ReactionEventModel.metadata.drop_all(engine)
+
+    @pytest.fixture()
+    def session(self, setup_database):
+        """Create a new database session for each test."""
+        session_local = sessionmaker(bind=setup_database, expire_on_commit=False)
+        session = session_local()
+        yield session
+        session.close()
+
+    @pytest.fixture()
+    def setup_repository(self, session):
+        """Set up the repository with the test session."""
+        repository = PostgresReactionEventRepository(session=lambda: session)
+        return repository
+
+    def test_create_reaction_event(self, setup_repository):
+        repository = setup_repository
+
+        reaction_event_create = ReactionEventCreate(
+            bot_id=uuid4(),
+            reaction=Reaction.NEGATIVE,
+            source_adapter=MessageAdapter.SLACK,
+            source_adapter_message_id="123456.7890",
+            source_adapter_user_id="U1234567890",
+            message="Hi there!",
+        )
+
+        repository.create_reaction_event(reaction_event_create)

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -19,6 +19,7 @@ from chat import ChatEngineSelector, ChatOpenAI
 from chat.exceptions import ChatResponseGenerationError
 from bot.repository import BotModel
 from .reaction_event_repository import ReactionEventRepository
+from .reaction_event import ReactionEventCreate
 
 
 class TestSlackAdapter:
@@ -182,6 +183,34 @@ class TestSlackAdapter:
         return event
 
     @pytest.fixture
+    def mock_conversations_history(self):
+        return {
+            "messages": [
+                {
+                    "user": "U1234567890",
+                    "type": "message",
+                    "ts": "1731075911.249209",
+                    "bot_id": "B1234567890",
+                    "app_id": "A1234567890",
+                    "text": '<@U9876543210> asked: \n\n"Balls" ',
+                    "team": "T1234567890",
+                    "thread_ts": "1731075911.249209",
+                    "reply_count": 1,
+                    "reply_users_count": 1,
+                    "latest_reply": "1731075911.854659",
+                    "metadata": {
+                        "event_type": "chat-data",
+                        "event_payload": {"bot_slug": "management-1"},
+                    },
+                    "reactions": [
+                        {"name": "laughing", "users": ["U9876543210"], "count": 1},
+                        {"name": "-1", "users": ["U9876543210"], "count": 1},
+                    ],
+                }
+            ]
+        }
+
+    @pytest.fixture
     def mock_negative_reaction_event(self):
         return self.mock_reaction_added_event("-1")
 
@@ -313,13 +342,130 @@ class TestSlackAdapter:
 
     @pytest.mark.asyncio
     async def test_negative_reaction(
-        self, mock_negative_reaction_event, mock_slack_adapter
+        self,
+        mock_negative_reaction_event,
+        mock_slack_adapter,
+        mock_conversations_history,
     ):
         negative_reaction = mock_negative_reaction_event
-        _, _, _, slack_adapter = mock_slack_adapter
+        _, _, bot_service, slack_adapter = mock_slack_adapter
+
+        slack_adapter.app.client.conversations_history.return_value = (
+            mock_conversations_history
+        )
+
+        bot_service.get_chatbot_by_slug.return_value = BotResponse(
+            id=uuid4(),
+            name="Bot B",
+            system_prompt="a much longer prompt B here",
+            slug="management-1",
+            model=ModelEngine.OPENAI,
+            adapter=MessageAdapter.SLACK,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            updated_at_relative=relative_time(datetime.now()),
+        )
 
         # will add logic in next PR
         slack_adapter.negative_reaction(event=negative_reaction)
+
+        slack_adapter.app.client.conversations_history.assert_called_once()
+        bot_service.get_chatbot_by_slug.assert_called_once()
+        slack_adapter.reaction_event_repository.create_reaction_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_negative_reaction_not_parent_message(
+        self,
+        mock_negative_reaction_event,
+        mock_slack_adapter,
+        mock_conversations_history,
+    ):
+        negative_reaction = mock_negative_reaction_event
+        _, _, bot_service, slack_adapter = mock_slack_adapter
+        conversations_history = mock_conversations_history
+        conversations_history["messages"][0]["thread_ts"] = "completely-different-id"
+
+        slack_adapter.app.client.conversations_history.return_value = (
+            conversations_history
+        )
+
+        # will add logic in next PR
+        slack_adapter.negative_reaction(event=negative_reaction)
+
+        slack_adapter.app.client.conversations_history.assert_called_once()
+        bot_service.get_chatbot_by_slug.assert_not_called()
+        slack_adapter.reaction_event_repository.create_reaction_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_reaction_no_metadata(
+        self,
+        mock_negative_reaction_event,
+        mock_slack_adapter,
+        mock_conversations_history,
+    ):
+        negative_reaction = mock_negative_reaction_event
+        _, _, bot_service, slack_adapter = mock_slack_adapter
+        conversations_history = mock_conversations_history
+        conversations_history["messages"][0]["metadata"] = None
+
+        slack_adapter.app.client.conversations_history.return_value = (
+            conversations_history
+        )
+
+        # will add logic in next PR
+        slack_adapter.negative_reaction(event=negative_reaction)
+
+        slack_adapter.app.client.conversations_history.assert_called_once()
+        bot_service.get_chatbot_by_slug.assert_not_called()
+        slack_adapter.reaction_event_repository.create_reaction_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_reaction_invalid_event(
+        self,
+        mock_negative_reaction_event,
+        mock_slack_adapter,
+        mock_conversations_history,
+    ):
+        negative_reaction = mock_negative_reaction_event
+        _, _, bot_service, slack_adapter = mock_slack_adapter
+        conversations_history = mock_conversations_history
+        conversations_history["messages"][0]["metadata"][
+            "event_type"
+        ] = "some-random-event"
+
+        slack_adapter.app.client.conversations_history.return_value = (
+            conversations_history
+        )
+
+        # will add logic in next PR
+        slack_adapter.negative_reaction(event=negative_reaction)
+
+        slack_adapter.app.client.conversations_history.assert_called_once()
+        bot_service.get_chatbot_by_slug.assert_not_called()
+        slack_adapter.reaction_event_repository.create_reaction_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_reaction_chatbot_not_found(
+        self,
+        mock_negative_reaction_event,
+        mock_slack_adapter,
+        mock_conversations_history,
+    ):
+        negative_reaction = mock_negative_reaction_event
+        _, _, bot_service, slack_adapter = mock_slack_adapter
+
+        slack_adapter.app.client.conversations_history.return_value = (
+            mock_conversations_history
+        )
+
+        bot_service.get_chatbot_by_slug.return_value = None
+
+        # will add logic in next PR
+        slack_adapter.negative_reaction(event=negative_reaction)
+
+        slack_adapter.app.client.conversations_history.assert_called_once()
+        bot_service.get_chatbot_by_slug.assert_called_once()
+        slack_adapter.reaction_event_repository.create_reaction_event.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ask_form(

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -165,7 +165,7 @@ class TestSlackAdapter:
         event = {
             "type": "reaction_added",
             "user": "U1234567890",
-            "reaction": "-1",
+            "reaction": reaction,
             "item": {
                 "type": "message",
                 "channel": "C1234567890",

--- a/adapter/test_slack.py
+++ b/adapter/test_slack.py
@@ -18,6 +18,7 @@ from bot.helper import relative_time
 from chat import ChatEngineSelector, ChatOpenAI
 from chat.exceptions import ChatResponseGenerationError
 from bot.repository import BotModel
+from .reaction_event_repository import ReactionEventRepository
 
 
 class TestSlackAdapter:
@@ -29,8 +30,12 @@ class TestSlackAdapter:
             mock_engine_selector.select_engine = MagicMock(return_value=ChatOpenAI())
             mock_chatbot = mock_engine_selector.select_engine()
             mock_bot_service = MagicMock(spec=BotService)
+            mock_reaction_event_repository = MagicMock(spec=ReactionEventRepository)
             slack_adapter = SlackAdapter(
-                mock_app, mock_engine_selector, mock_bot_service
+                mock_app,
+                mock_engine_selector,
+                mock_bot_service,
+                mock_reaction_event_repository,
             )
             return mock_app, mock_chatbot, mock_bot_service, slack_adapter
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from slack_bolt import App
 
-from adapter import SlackAdapter
+from adapter import SlackAdapter, PostgresReactionEventRepository
 from auth.controller import AuthControllerV1
 from auth.repository import PostgresAuthRepository
 from auth.service import AuthServiceV1
@@ -77,14 +77,21 @@ if __name__ == "__main__":
     engine_selector = ChatEngineSelector(
         openai_api_key=config.openai_api_key, anthropic_api_key=config.anthropic_api_key
     )
-    
+
     document_repository = PostgresDocumentRepository(sessionmaker)
 
     document_service = DocumentServiceV1(document_repository)
 
     document_controller = DocumentControllerV1(document_service)
 
-    slack_adapter = SlackAdapter(slack_app, engine_selector, bot_service)
+    reaction_event_repository = PostgresReactionEventRepository(sessionmaker)
+
+    slack_adapter = SlackAdapter(
+        slack_app,
+        engine_selector,
+        bot_service,
+        reaction_event_repository,
+    )
 
     slack_app.event("message")(slack_adapter.event_message)
     slack_app.event("reaction_added")(slack_adapter.reaction_added)


### PR DESCRIPTION
This PR enables the handling of negative reactions from Slack into reaction event analytics to be used for the performance analytics of a chatbot for next sprint. This PR builds upon #61 and #62 which handles the saving of a reaction event received from the listener into our system