### PR TITLE
feat: add presigned url for docs

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -110,6 +110,10 @@ class AppConfig:
         if not found:
             invalid = True
 
+        self.aws_endpoint_url, found = self.validate_env_var("AWS_ENDPOINT_URL")
+        if not found:
+            invalid = True
+
         if invalid:
             raise ValueError("invalid app config")
 

--- a/config/test_config.py
+++ b/config/test_config.py
@@ -34,6 +34,7 @@ class TestAppConfig:
         monkeypatch.setenv("AWS_REGION", "ap-test")
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "test")
 
         config = AppConfig()
 
@@ -71,6 +72,7 @@ class TestAppConfig:
         monkeypatch.setenv("AWS_REGION", "ap-test")
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "test")
         monkeypatch.setenv("MAXIMUM_ACCESS_LEVEL", "5")
         monkeypatch.setenv("ADMIN_EMAILS", "admin@broom.id,user@broom.id")
 

--- a/document/__init__.py
+++ b/document/__init__.py
@@ -1,4 +1,4 @@
-from .document import Document, DocumentType, DocumentTitleError, DocumentTypeError, ObjectNameError
+from .document import Document, DocumentType, DocumentTitleError, DocumentTypeError, ObjectNameError, DocumentPresignedURLError
 from .dto import DocumentFilter, DocumentCreate, DocumentUpdate, DocumentResponse
 from .controller import DocumentController, DocumentControllerV1
 from .service import DocumentService, DocumentServiceV1

--- a/document/__init__.py
+++ b/document/__init__.py
@@ -3,3 +3,4 @@ from .dto import DocumentFilter, DocumentCreate, DocumentUpdate, DocumentRespons
 from .controller import DocumentController, DocumentControllerV1
 from .service import DocumentService, DocumentServiceV1
 from .repository import DocumentRepository, PostgresDocumentRepository
+from .utils import generate_presigned_url

--- a/document/conftest.py
+++ b/document/conftest.py
@@ -96,3 +96,8 @@ def dummy_user_profile():
 def setup_jwt_secret():
     """Set up a mock JWT secret."""
     return "some_arbitrary_secret_here"
+
+@pytest.fixture
+def mock_boto_client():
+    """Fixture to mock the boto3 S3 client"""
+    return MagicMock()

--- a/document/conftest.py
+++ b/document/conftest.py
@@ -36,7 +36,8 @@ def setup_service(mock_boto_client, setup_repository):
     aws_config = AWSConfig(aws_access_key_id="test_access_key",
                            aws_secret_access_key="test_secret_key", 
                            aws_public_bucket_name="test_bucket", 
-                           aws_region="ap-test-3")
+                           aws_region="ap-test-3",
+                           aws_endpoint_url="aws-endpoint")
     service = DocumentServiceV1(
         aws_config,
         repository=setup_repository

--- a/document/document.py
+++ b/document/document.py
@@ -19,6 +19,11 @@ class DocumentTypeError(Exception):
         self.message = message
         super().__init__(self.message)  
 
+class DocumentPresignedURLError(Exception):
+    def __init__(self, message="Failed to generate presigned URL"):
+        self.message = message
+        super().__init__(self.message)
+
 class DocumentType(str, Enum):
     CSV = "csv"
     PDF = "pdf"
@@ -58,4 +63,12 @@ class Document(BaseModel):
         A presigned URL string for an S3 object, that does not require additional auth or API keys to access.
 
         '''
-        raise NotImplementedError
+        try:
+            response = s3_client.generate_presigned_url(
+                'get_object',
+                Params={'Bucket': bucket_name, 'Key': self.object_name},
+                ExpiresIn=expiration
+            )
+            return response
+        except ClientError:
+            raise DocumentPresignedURLError

--- a/document/dto.py
+++ b/document/dto.py
@@ -41,3 +41,4 @@ class AWSConfig(BaseModel):
     aws_secret_access_key: str
     aws_public_bucket_name: str
     aws_region: str
+    aws_endpoint_url: str

--- a/document/service.py
+++ b/document/service.py
@@ -49,6 +49,7 @@ class DocumentServiceV1(DocumentService):
             aws_access_key_id=aws_config.aws_access_key_id,
             aws_secret_access_key=aws_config.aws_secret_access_key,
             region_name=aws_config.aws_region,
+            endpoint_url=aws_config.aws_endpoint_url
         )
         self.bucket_name = aws_config.aws_public_bucket_name
         self.logger = logger.bind(service="DocumentService")

--- a/document/test_document.py
+++ b/document/test_document.py
@@ -61,3 +61,40 @@ class TestDocument:
                 updated_at=None
             )
         assert len(excinfo.value.errors()) > 0  # Multiple validation errors raised
+
+    @patch("boto3.client")
+    def test_generate_presigned_url_success(self, mock_s3_client):
+        # Arrange
+        document = create_valid_document()
+        document.object_name = "sample.csv"
+        presigned_url = "https://example.com/sample.csv?X-Amz-Security-Token=..."
+        
+        # Mock S3 client response for generate_presigned_url
+        mock_s3_client.return_value.generate_presigned_url.return_value = presigned_url
+        
+        # Act
+        response = document.generate_presigned_url(mock_s3_client.return_value, "test-bucket")
+
+        # Assert
+        assert response == presigned_url
+        mock_s3_client.return_value.generate_presigned_url.assert_called_once_with(
+            'get_object',
+            Params={'Bucket': "test-bucket", 'Key': "sample.csv"},
+            ExpiresIn=28800
+        )
+
+    @patch("boto3.client")
+    def test_generate_presigned_url_failure(self, mock_s3_client):
+        # Arrange
+        document = create_valid_document()
+        document.object_name = "sample.csv"
+        
+        # Simulate a ClientError when generate_presigned_url is called
+        mock_s3_client.return_value.generate_presigned_url.side_effect = ClientError(
+            error_response={"Error": {"Code": "403", "Message": "Forbidden"}},
+            operation_name="generate_presigned_url"
+        )
+        
+        # Act & Assert
+        with pytest.raises(DocumentPresignedURLError):
+            document.generate_presigned_url(mock_s3_client.return_value, "test-bucket")

--- a/document/test_document.py
+++ b/document/test_document.py
@@ -2,7 +2,9 @@ from pydantic import ValidationError
 import pytest
 from datetime import datetime
 from uuid import uuid4
-from document import Document, DocumentTitleError, DocumentType, DocumentTypeError, ObjectNameError
+from unittest.mock import Mock, patch
+from document import Document, DocumentTitleError, DocumentType, DocumentTypeError, ObjectNameError, DocumentPresignedURLError
+from botocore.exceptions import ClientError
 
 # Helper to create a valid document
 def create_valid_document():

--- a/document/test_utils.py
+++ b/document/test_utils.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import MagicMock
+from document.utils import generate_presigned_url
+from document.document import DocumentPresignedURLError
+
+class TestGeneratePresignedURL:
+    @pytest.fixture()
+    def mock_s3_client(self, mock_boto_client):
+        """Fixture to mock the S3 client"""
+        mock_client = MagicMock()
+        mock_client.generate_presigned_url.return_value = "http://mockurl.com"
+        mock_boto_client.return_value = mock_client
+        return mock_client
+
+    
+    def test_generate_presigned_url_success(self, mock_s3_client, setup_documents):
+        """Test the happy path where URL is generated successfully"""
+        # Use the first document from the setup_documents fixture
+        doc_model = setup_documents[0]
+        bucket_name = "mock-bucket"
+
+        # Call the generate_presigned_url function
+        url = generate_presigned_url(doc_model, mock_s3_client, bucket_name)
+
+        # Assert the S3 client's generate_presigned_url method was called with the expected parameters
+        mock_s3_client.generate_presigned_url.assert_called_once_with(
+            'get_object',
+            Params={'Bucket': bucket_name, 'Key': doc_model.object_name},
+            ExpiresIn=28800
+        )
+
+        # Assert the generated URL is correct
+        assert url == "http://mockurl.com"
+
+    def test_generate_presigned_url_failure(self, mock_s3_client, setup_documents):
+        """Test the failure path when presigned URL generation fails"""
+        # Use the first document from the setup_documents fixture
+        doc_model = setup_documents[0]
+        bucket_name = "mock-bucket"
+
+        # Simulate a failure in generating the presigned URL
+        mock_s3_client.generate_presigned_url.side_effect = DocumentPresignedURLError
+
+        # Call the generate_presigned_url function and assert that it raises the custom error
+        with pytest.raises(DocumentPresignedURLError, match="Failed to generate presigned URL"):
+            generate_presigned_url(doc_model, mock_s3_client, bucket_name)

--- a/document/test_utils.py
+++ b/document/test_utils.py
@@ -8,7 +8,7 @@ class TestGeneratePresignedURL:
     def mock_s3_client(self, mock_boto_client):
         """Fixture to mock the S3 client"""
         mock_client = MagicMock()
-        mock_client.generate_presigned_url.return_value = "http://mockurl.com"
+        mock_client.generate_presigned_url.return_value = "https://mockurl.com"
         mock_boto_client.return_value = mock_client
         return mock_client
 
@@ -30,7 +30,7 @@ class TestGeneratePresignedURL:
         )
 
         # Assert the generated URL is correct
-        assert url == "http://mockurl.com"
+        assert url == "https://mockurl.com"
 
     def test_generate_presigned_url_failure(self, mock_s3_client, setup_documents):
         """Test the failure path when presigned URL generation fails"""

--- a/document/utils.py
+++ b/document/utils.py
@@ -21,14 +21,5 @@ def generate_presigned_url(doc_model, s3_client, bucket_name: str, expiration: i
     -----
     DocumentPresignedURLError: If generating the presigned URL fails.
     """
-
-    doc_data = {
-                "id": doc_model.id,
-                "type": doc_model.type,
-                "title": doc_model.title,
-                "object_name": doc_model.object_name,
-                "created_at": doc_model.created_at,
-                "updated_at": doc_model.updated_at
-            }
-    document_obj = Document(**doc_data)
+    document_obj = Document(**doc_model.__dict__)
     return document_obj.generate_presigned_url(s3_client, bucket_name, expiration)

--- a/document/utils.py
+++ b/document/utils.py
@@ -1,0 +1,34 @@
+from document.document import Document
+
+
+def generate_presigned_url(doc_model, s3_client, bucket_name: str, expiration: int = 28800) -> str:
+    """
+    Generates and returns a new presigned S3 URL.
+
+    Parameters
+    -----
+    doc_model: Document Model.
+    s3_client: boto3 S3 client instance
+        The initialized S3 client to use for URL generation.
+    bucket_name (str): Name of the S3 bucket where the object is stored.
+    expiration (int): Time until presigned URL expires, in seconds. Default is 28800s (8 hours).
+
+    Returns
+    -----
+    A presigned URL string for an S3 object that does not require additional auth or API keys to access.
+
+    Raises
+    -----
+    DocumentPresignedURLError: If generating the presigned URL fails.
+    """
+
+    doc_data = {
+                "id": doc_model.id,
+                "type": doc_model.type,
+                "title": doc_model.title,
+                "object_name": doc_model.object_name,
+                "created_at": doc_model.created_at,
+                "updated_at": doc_model.updated_at
+            }
+    document_obj = Document(**doc_data)
+    return document_obj.generate_presigned_url(s3_client, bucket_name, expiration)

--- a/main.py
+++ b/main.py
@@ -55,7 +55,8 @@ if __name__ == "__main__":
         aws_access_key_id=config.aws_access_key_id,
         aws_secret_access_key=config.aws_secret_access_key,
         aws_public_bucket_name=config.aws_public_bucket_name,
-        aws_region=config.aws_region
+        aws_region=config.aws_region,
+        aws_endpoint_url=config.aws_endpoint_url
     )
 
     configure_logger(config.log_level)


### PR DESCRIPTION
### Summary of Changes

### Presigned URL Method for Documents
- Added a method to generate presigned URLs for S3-stored documents, allowing temporary access to document files.
- Added function in utils.py to generate presigned URLs from DocumentModel


### Endpoint Configuration in S3 Client Initialization
- Configured the S3 client to use the appropriate AWS endpoint URL, addressing issues related to region constraints (e.g., ap-southeast-3).
- Ensures that the presigned URL points to the correct regional endpoint.

### Unit Tests for Presigned URL
- Added tests for the presigned URL
- Configured test settings to include the correct endpoint URL