### PR TITLE
feat/document-create: Document Creation

### DIFF
--- a/bot/templates/navbar.html
+++ b/bot/templates/navbar.html
@@ -7,6 +7,7 @@
 
             {% if user_profile %}
                 <a href="/" class="text-lg font-semibold text-gray-700 hover:text-blue-500">Chatbot Library</a>
+                <a href="/document" class="text-lg font-semibold text-gray-700 hover:text-blue-500">Documents</a>
                 {% if user_profile.email in admin_emails %}
                     <a href="/users" class="text-lg font-semibold text-gray-700 hover:text-blue-500">Users</a>
                 {% endif %}

--- a/data_source/view.py
+++ b/data_source/view.py
@@ -39,3 +39,11 @@ class DataSourceViewV1(DataSourceView):
                 "user_profile": user_profile.get("data")
             }
         )
+        
+    @login_required()
+    def new_document_view(self, request: Request):
+        user_profile = self.auth_controller.user_profile_google(request)
+        return self.templates.TemplateResponse(
+            request=request, 
+            name="new-document.html", 
+        )

--- a/data_source/view.py
+++ b/data_source/view.py
@@ -39,11 +39,3 @@ class DataSourceViewV1(DataSourceView):
                 "user_profile": user_profile.get("data")
             }
         )
-        
-    @login_required()
-    def new_document_view(self, request: Request):
-        user_profile = self.auth_controller.user_profile_google(request)
-        return self.templates.TemplateResponse(
-            request=request, 
-            name="new-document.html", 
-        )

--- a/document/templates/document-list.html
+++ b/document/templates/document-list.html
@@ -29,17 +29,19 @@
                         <th class="px-4 py-2 text-left">Updated At</th>
                     </tr>
                 </thead>
-                <tbody>
-                    {% for document in documents %}
-                    <tr class="border-t">
-                        <td class="px-4 py-2">{{ document.title }}</td>
-                        <td class="px-4 py-2">{{ document.type }}</td>
-                        <td class="px-4 py-2">{{ document.object_name }}</td>
-                        <td class="px-4 py-2">{{ document.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-                        <td class="px-4 py-2">{{ document.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
+                {% if documents %}
+                    <tbody>
+                        {% for document in documents %}
+                            <tr class="border-t">
+                                <td class="px-4 py-2">{{ document.title }}</td>
+                                <td class="px-4 py-2">{{ document.type }}</td>
+                                <td class="px-4 py-2">{{ document.object_name }}</td>
+                                <td class="px-4 py-2">{{ document.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                                <td class="px-4 py-2">{{ document.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                {% endif %}
             </table>
         </div>
         <div class="mt-4 flex justify-center">

--- a/document/templates/new-document.html
+++ b/document/templates/new-document.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Document - Broom.id</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.0.0/dist/css/tom-select.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.0.0/dist/js/tom-select.complete.min.js"></script>
+    <script>
+      function showFileName() {
+        const fileInput = document.getElementById('file');
+        const fileNameDisplay = document.getElementById('file-name');
+        const fileName = fileInput.files.length > 0 ? fileInput.files[0].name : "No file selected";
+        
+        const fileSelect = document.getElementById('file-select');
+        fileSelect.textContent = "Select Another File"
+
+        fileNameDisplay.textContent = fileName;
+      }
+    </script>
+</head>
+<body class="bg-gray-100">
+    <!-- Navbar -->
+    {% set title = 'New Document' %}
+    {% include 'navbar.html' %}
+
+    <main class="container mx-auto mt-8 px-4">
+        <form 
+            id="chatbot-form" 
+            method="POST" 
+            action="/api/documents"  
+            enctype="multipart/form-data" 
+            class="bg-white shadow-md rounded-lg p-6" 
+        >
+            <div class="mb-4">
+                <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Document Title</label>
+                <input type="text" id="title" name="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" placeholder="Enter title of document">
+            </div>
+            
+            <div class="mb-4">
+                <label for="object_name" class="block text-gray-700 text-sm font-bold mb-2">Object Name</label>
+                <textarea id="object_name" name="object_name" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" rows="4" placeholder="Enter a unique identifier for document file"></textarea>
+            </div>
+
+            <div class="mb-4">
+              <label for="file" class="block text-gray-700 text-sm font-bold mb-2">File</label>
+              <div class="border border-dashed border-gray-500 relative text-gray-700 text-sm">
+                  <input 
+                    type="file" 
+                    id="file" 
+                    class="cursor-pointer relative block opacity-0 w-full h-full p-10 z-50"
+                    onchange="showFileName()"
+                    name="file"
+                  >
+                  <div class="text-center py-5 absolute top-0 right-0 left-0 m-auto">
+                      <h4 id="file-name">
+                          Drop file anywhere to upload
+                          <br/>or
+                      </h4>
+                      <p class="font-bold" id="file-select">Select File</p>
+                  </div>
+                  <!-- <p id="file-name" class="text-center mt-4 text-gray-700"></p> -->
+              </div>
+            </div>
+            
+            <div class="mb-4">
+                <label for="type" class="block text-gray-700 text-sm font-bold mb-2">Documentz Type</label>
+                <select id="type" name="type" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                    {% for type in document_types %}
+                        <option 
+                            value="{{ type }}"
+                        >
+                            {{ type }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="mb-4">
+                <label for="access_level" class="block text-gray-700 text-sm font-bold mb-2">Access Level</label>
+                <select id="access_level" name="access_level" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                    {% for level in access_levels %}
+                        <option value="{{ level }}">{{ level }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="flex items-center justify-end">
+                <button id="create-bot-button" type="submit" 
+                        class="text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-all" 
+                        style="background-color: #2a4365;" 
+                        onmouseover="this.style.backgroundColor='#1e3150'" 
+                        onmouseout="this.style.backgroundColor='#2a4365'"
+                        onfocus="this.style.backgroundColor='#1e3150'" 
+                        onblur="this.style.backgroundColor='#2a4365'">
+                    Create Document
+                </button>
+            </div>
+        </form>
+    </main>
+</body>
+</html>

--- a/document/templates/new-document.html
+++ b/document/templates/new-document.html
@@ -60,7 +60,6 @@
                       </h4>
                       <p class="font-bold" id="file-select">Select File</p>
                   </div>
-                  <!-- <p id="file-name" class="text-center mt-4 text-gray-700"></p> -->
               </div>
             </div>
             

--- a/document/view.py
+++ b/document/view.py
@@ -3,9 +3,11 @@ from fastapi import Request
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment
 import jinja2
+from loguru import logger
 
 from auth.controller import AuthController
 from auth.middleware import login_required
+from document.document import DocumentType
 from document.dto import DocumentFilter
 from document.service import DocumentService
 
@@ -25,6 +27,7 @@ class DocumentViewV1(DocumentView):
         )
         self.auth_controller = auth_controller
         self.service = document_service
+        self.logger = logger.bind(service="DocumentView")
 
     @login_required()
     def show_list_documents(self, request: Request):
@@ -36,5 +39,19 @@ class DocumentViewV1(DocumentView):
             context={
                 "documents": documents,
                 "user_profile": user_profile.get("data")
+            }
+        )
+        
+    @login_required()
+    def new_document_view(self, request: Request):
+        user_profile = self.auth_controller.user_profile_google(request)
+        max_level = user_profile.get('data').access_level
+        self.logger.info(f"user has access level {max_level}")
+        return self.templates.TemplateResponse(
+            request=request, 
+            name="new-document.html", 
+            context={
+                "document_types": [x.lower() for x in DocumentType._member_names_],
+                "access_levels": [i for i in range(0, int(max_level) + 1)],
             }
         )

--- a/main.py
+++ b/main.py
@@ -155,6 +155,13 @@ if __name__ == "__main__":
         response_class=HTMLResponse,
         description="Page that displays all users",
     )
+    
+    app.add_api_route(
+        "/new-data-source",
+        endpoint=data_source_view.new_document_view,
+        response_class=HTMLResponse,
+        description="Page that displays Document Creation form",
+    )
 
     app.add_api_route(
         "/api/bots",

--- a/main.py
+++ b/main.py
@@ -157,8 +157,8 @@ if __name__ == "__main__":
     )
     
     app.add_api_route(
-        "/new-data-source",
-        endpoint=data_source_view.new_document_view,
+        "/create-document",
+        endpoint=document_view.new_document_view,
         response_class=HTMLResponse,
         description="Page that displays Document Creation form",
     )


### PR DESCRIPTION
## Summary

Implement Document Creation form (frontend) for CMS. Includes access level integration, and depends on #69 

## Changes
- modify `bot/templates/navbar.html` to show "Documents" at the top
- add `new-document.html` template
- add view
- modify `list-document.html` to handle if documents=None (no documents) logic
- add unit tests for Document Creation form
- the form includes a FILE UPLOAD

## Detailed Implementation for Create Document Form

- page is on `/create-document` (or click Add button on list documents page)
- title: text area
- object_name: text area (UNIQUE)
- upload file
- document type: dropdown (default csv, options csv pdf txt)
- access level: dropdown (default 0, range 0 to <user's access level>)

## Not Included
- document access level integration (done in #69 )
- handling if user does not have access level
- handling if access level is negative
- **handle redirect after user submits new Document**
- error handling on form submission error