### PR TITLE
[SAP-23, SAP-24] Add tracing to ask and generate respond features 

### DIFF
--- a/adapter/slack.py
+++ b/adapter/slack.py
@@ -63,7 +63,6 @@ class SlackAdapter:
 
     @sentry_sdk.trace
     async def handle_interactions(self, req: Request):
-        transaction = sentry_sdk.get_current_scope().transaction
         data = await req.form()
 
         payload_str = data.get("payload")
@@ -73,8 +72,7 @@ class SlackAdapter:
         if len(actions) == 1:
             action_id = actions[0]["action_id"]
 
-            if transaction is not None:  # pragma: no cover
-                transaction.set_tag("action_id", action_id)
+            sentry_sdk.get_current_scope().set_tag("action_id", action_id)
 
             self.logger().bind(action_id=action_id).info("handling interaction")
             if action_id == "ask_question":
@@ -85,9 +83,8 @@ class SlackAdapter:
                 ]["value"]
                 question = payload["state"]["values"]["question"]["question"]["value"]
 
-                if transaction is not None:  # pragma: no cover
-                    transaction.set_tag("slug", slug)
-                    transaction.set_tag("question", question)
+                sentry_sdk.get_current_scope().set_tag("slug", slug)
+                sentry_sdk.get_current_scope().set_tag("question", question)
 
                 try:
                     await self.ask_v2(

--- a/web/logging.py
+++ b/web/logging.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 import time
 import traceback
 
@@ -17,8 +18,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
-
-        request_id: str = str(uuid4())
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:  # pragma: no cover
+            request_id = transaction.trace_id
+        else:
+            request_id: str = str(uuid4())
 
         with logger.contextualize(trace_id=request_id):
             logging_dict = {"trace_id": request_id}


### PR DESCRIPTION
This PR demonstrates the capabilities of distributed tracing for Sapungobrol by tracing the lifecycle of a user's request starting from sending their question via Slack using the `ask_v2` command form up until they receive a response. The goal is to help us visualize the bottlenecks and paths of our system and help us trace where errors and latencies happen easier. Incorporating this with our logs using the `trace_id` makes it a lot easier to debug errors since we know where to look a lot faster.

Here's a sample of the trace I took as well as the logs
![trace](https://github.com/user-attachments/assets/101ec356-c7c4-4b0a-a1b2-3234da531a7d)

```json
{"level": "INFO", "timestamp": "2024-11-19T23:09:38.226014+07:00", "function": "handle_interactions", "message": "handling interaction", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "service": "SlackAdapter", "action_id": "ask_question"}
{"level": "INFO", "timestamp": "2024-11-19T23:09:38.227059+07:00", "function": "ask_v2", "message": "answering question", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "service": "SlackAdapter"}
{"level": "INFO", "timestamp": "2024-11-19T23:09:39.462461+07:00", "function": "process_chatbot_request", "message": "Processing query using chatbot", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "service": "SlackAdapter"}
{"level": "INFO", "timestamp": "2024-11-19T23:09:40.228379+07:00", "function": "send_generated_response", "message": "generating response", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "service": "SlackAdapter"}
{"level": "INFO", "timestamp": "2024-11-19T23:09:40.896262+07:00", "function": "dispatch", "message": "Incoming request", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "request": {"method": "POST", "path": "/api/slack/interactivity", "origin_ip": "44.222.108.41", "user_agent": "Slackbot 1.0 (+https://api.slack.com/robots)"}, "response": {"status": 200, "elapsed_time": "2.6718s"}}
Although the app should be installed into this workspace, the AuthorizeResult (returned value from authorize) for it was not found.
Although the app should be installed into this workspace, the AuthorizeResult (returned value from authorize) for it was not found.
{"level": "INFO", "timestamp": "2024-11-19T23:09:40.915713+07:00", "function": "dispatch", "message": "Incoming request", "trace_id": "c2fec9a3a3ac49c7837dfedf4498f55e", "request": {"method": "POST", "path": "/api/slack/events", "origin_ip": "44.210.79.23", "user_agent": "Slackbot 1.0 (+https://api.slack.com/robots)"}, "response": {"status": 200, "elapsed_time": "0.0161s"}}
{"level": "INFO", "timestamp": "2024-11-19T23:09:40.919949+07:00", "function": "dispatch", "message": "Incoming request", "trace_id": "7726f58f9d09416596d009571ae2c93b", "request": {"method": "POST", "path": "/api/slack/events", "origin_ip": "34.207.152.231", "user_agent": "Slackbot 1.0 (+https://api.slack.com/robots)"}, "response": {"status": 200, "elapsed_time": "0.0160s"}}
{"level": "INFO", "timestamp": "2024-11-19T23:09:43.336736+07:00", "function": "send_generated_response", "message": "sending generated response", "trace_id": "d11babefc5ef4eb09cfcc42edb73bf6e", "service": "SlackAdapter"}
```

If you noticed, the user receives a response in 2.68 seconds. However, they only get to see the actual answer once it's finished generating which is 5.69 seconds in total. The time it takes to generate an answer wouldn't be possible to know based on the logs alone. The trace helps us visualize that a lot better as it captured the time to generate the response.